### PR TITLE
Updates Configs to Match New Structure in Release 1.0.1

### DIFF
--- a/sef-ecosystems-biodiversity/config.json
+++ b/sef-ecosystems-biodiversity/config.json
@@ -34,11 +34,7 @@
       "isActive": false,
       "layout": {
         "layerCard": {
-          "toggleable": true,
-          "attribution": {
-            "text": "EOC Basemap Map Service",
-            "url": "https://geoservice.dlr.de/web/"
-          }
+          "toggleable": true
         },
         "interfaceGroup": "Basemaps"
       },
@@ -50,6 +46,12 @@
         "exclusivitySets": [
           "labels"
         ]
+      },
+      "meta": {
+        "attribution": {
+          "text": "EOC Basemap Map Service",
+          "url": "https://geoservice.dlr.de/web/"
+        }
       }
     },
     {
@@ -57,7 +59,6 @@
       "isActive": false,
       "layout": {
         "layerCard": {
-          "description": "Provides at global level spatial information on different types (classes) of physical coverage of the Earth's surface, e.g. forests, grasslands, croplands, lakes, wetlands for the 2019 base year. The data are updated annually and are available for the 2015-2019 years.",
           "toggleable": true,
           "controls": [
             "zoomToCenter"
@@ -66,10 +67,6 @@
             "type": "image",
             "visible": true,
             "data": "https://land.copernicus.eu/en/products/global-dynamic-land-cover/map-legends/single_class_forest.png/@@images/image-220-1d593b046e598a8ba51609a1bd8afa5c.png"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
           }
         },
         "interfaceGroup": "Copernicus Land - Land Cover"
@@ -78,6 +75,13 @@
         "url": "https://s3-eu-west-1.amazonaws.com/vito-lcv/global/2019/cog-full_l0-colored-full/{z}/{x}/{-y}.png",
         "zIndex": 2,
         "type": "xyz"
+      },
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
+        },
+        "description": "Provides at global level spatial information on different types (classes) of physical coverage of the Earth's surface, e.g. forests, grasslands, croplands, lakes, wetlands for the 2019 base year. The data are updated annually and are available for the 2015-2019 years."
       }
     },
     {
@@ -85,7 +89,6 @@
       "isActive": false,
       "layout": {
         "layerCard": {
-          "description": "Provides at global level spatial information on different types (classes) of physical coverage of the Earth's surface, e.g. forests, grasslands, croplands, lakes, wetlands for the 2018 base year. The data are updated annually and are available for the 2015-2019 years.",
           "toggleable": true,
           "controls": [
             "zoomToCenter"
@@ -94,10 +97,6 @@
             "type": "image",
             "visible": true,
             "data": "https://land.copernicus.eu/en/products/global-dynamic-land-cover/map-legends/single_class_forest.png/@@images/image-220-1d593b046e598a8ba51609a1bd8afa5c.png"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
           }
         },
         "interfaceGroup": "Copernicus Land - Land Cover"
@@ -106,6 +105,13 @@
         "url": "https://s3-eu-west-1.amazonaws.com/vito-lcv/global/2018/cog-full_l0-colored-full/{z}/{x}/{-y}.png",
         "zIndex": 2,
         "type": "xyz"
+      },
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
+        },
+        "description": "Provides at global level spatial information on different types (classes) of physical coverage of the Earth's surface, e.g. forests, grasslands, croplands, lakes, wetlands for the 2018 base year. The data are updated annually and are available for the 2015-2019 years."
       }
     },
     {
@@ -113,7 +119,6 @@
       "isActive": false,
       "layout": {
         "layerCard": {
-          "description": "Provides at global level spatial information on different types (classes) of physical coverage of the Earth's surface, e.g. forests, grasslands, croplands, lakes, wetlands for the 2017 base year. The data are updated annually and are available for the 2015-2019 years.",
           "toggleable": true,
           "controls": [
             "zoomToCenter"
@@ -122,10 +127,6 @@
             "type": "image",
             "visible": true,
             "data": "https://land.copernicus.eu/en/products/global-dynamic-land-cover/map-legends/single_class_forest.png/@@images/image-220-1d593b046e598a8ba51609a1bd8afa5c.png"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
           }
         },
         "interfaceGroup": "Copernicus Land - Land Cover"
@@ -134,6 +135,13 @@
         "url": "https://s3-eu-west-1.amazonaws.com/vito-lcv/global/2017/cog-full_l0-colored-full/{z}/{x}/{-y}.png",
         "zIndex": 2,
         "type": "xyz"
+      },
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
+        },
+        "description": "Provides at global level spatial information on different types (classes) of physical coverage of the Earth's surface, e.g. forests, grasslands, croplands, lakes, wetlands for the 2017 base year. The data are updated annually and are available for the 2015-2019 years."
       }
     },
     {
@@ -141,7 +149,6 @@
       "isActive": false,
       "layout": {
         "layerCard": {
-          "description": "Provides at global level spatial information on different types (classes) of physical coverage of the Earth's surface, e.g. forests, grasslands, croplands, lakes, wetlands for the 2016 base year. The data are updated annually and are available for the 2015-2019 years.",
           "toggleable": true,
           "controls": [
             "zoomToCenter"
@@ -150,10 +157,6 @@
             "type": "image",
             "visible": true,
             "data": "https://land.copernicus.eu/en/products/global-dynamic-land-cover/map-legends/single_class_forest.png/@@images/image-220-1d593b046e598a8ba51609a1bd8afa5c.png"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
           }
         },
         "interfaceGroup": "Copernicus Land - Land Cover"
@@ -162,6 +165,13 @@
         "url": "https://s3-eu-west-1.amazonaws.com/vito-lcv/global/2016/cog-full_l0-colored-full/{z}/{x}/{-y}.png",
         "zIndex": 2,
         "type": "xyz"
+      },
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
+        },
+        "description": "Provides at global level spatial information on different types (classes) of physical coverage of the Earth's surface, e.g. forests, grasslands, croplands, lakes, wetlands for the 2016 base year. The data are updated annually and are available for the 2015-2019 years."
       }
     },
     {
@@ -169,7 +179,6 @@
       "isActive": false,
       "layout": {
         "layerCard": {
-          "description": "Provides at global level spatial information on different types (classes) of physical coverage of the Earth's surface, e.g. forests, grasslands, croplands, lakes, wetlands for the 2015 base year. The data are updated annually and are available for the 2015-2019 years.",
           "toggleable": true,
           "controls": [
             "zoomToCenter"
@@ -178,10 +187,6 @@
             "type": "image",
             "visible": true,
             "data": "https://land.copernicus.eu/en/products/global-dynamic-land-cover/map-legends/single_class_forest.png/@@images/image-220-1d593b046e598a8ba51609a1bd8afa5c.png"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
           }
         },
         "interfaceGroup": "Copernicus Land - Land Cover"
@@ -190,6 +195,13 @@
         "url": "https://s3-eu-west-1.amazonaws.com/vito-lcv/global/2015/cog-full_l0-colored-full/{z}/{x}/{-y}.png",
         "zIndex": 2,
         "type": "xyz"
+      },
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
+        },
+        "description": "Provides at global level spatial information on different types (classes) of physical coverage of the Earth's surface, e.g. forests, grasslands, croplands, lakes, wetlands for the 2015 base year. The data are updated annually and are available for the 2015-2019 years."
       }
     },
     {
@@ -197,7 +209,6 @@
       "isActive": false,
       "layout": {
         "layerCard": {
-          "description": "Provides a pan-European spatially consistent and seamless, detailed land cover inventory for the 2021 reference year, for each pixel showing the dominant land cover among the 11 basic land cover classes. The dataset is available as 10 m raster.",
           "toggleable": true,
           "controls": [
             "zoomToCenter"
@@ -206,10 +217,6 @@
             "type": "image",
             "visible": true,
             "data": "https://land.copernicus.eu/en/products/clc-backbone/map-legends/clc-backbone-2018_raster-10-m.png/@@images/image"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
           }
         },
         "interfaceGroup": "Copernicus Land - CLCplus Backbone"
@@ -219,6 +226,13 @@
         "layers": "CLMS_CLCplus_RASTER_2021_010m_eu",
         "zIndex": 2,
         "type": "wms"
+      },
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
+        },
+        "description": "Provides a pan-European spatially consistent and seamless, detailed land cover inventory for the 2021 reference year, for each pixel showing the dominant land cover among the 11 basic land cover classes. The dataset is available as 10 m raster."
       }
     },
     {
@@ -226,7 +240,6 @@
       "isActive": false,
       "layout": {
         "layerCard": {
-          "description": "Provides a pan-European spatially consistent and seamless, detailed land cover inventory for the 2018 reference year, for each pixel showing the dominant land cover among the 11 basic land cover classes. The dataset is available as 10 m raster.",
           "toggleable": true,
           "controls": [
             "zoomToCenter"
@@ -235,10 +248,6 @@
             "type": "image",
             "visible": true,
             "data": "https://land.copernicus.eu/en/products/clc-backbone/map-legends/clc-backbone-2018_raster-10-m.png/@@images/image"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
           }
         },
         "interfaceGroup": "Copernicus Land - CLCplus Backbone"
@@ -248,6 +257,13 @@
         "layers": "CLMS_CLCplus_RASTER_2018_010m_eu",
         "zIndex": 2,
         "type": "wms"
+      },
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
+        },
+        "description": "Provides a pan-European spatially consistent and seamless, detailed land cover inventory for the 2018 reference year, for each pixel showing the dominant land cover among the 11 basic land cover classes. The dataset is available as 10 m raster."
       }
     },
     {
@@ -255,7 +271,6 @@
       "isActive": false,
       "layout": {
         "layerCard": {
-          "description": "Provides a pan-European spatially consistent and seamless, detailed land cover inventory for the 2018 reference year, for each polygon showing the dominant land cover among the 18 basic land cover classes and additional attributes. The minimum mapping unit of the dataset is 0.5 ha.",
           "toggleable": true,
           "controls": [
             "zoomToCenter"
@@ -264,10 +279,6 @@
             "type": "image",
             "visible": true,
             "data": "https://copernicus.discomap.eea.europa.eu/arcgis/services/CLC_plus/CLCplus2018_WM/MapServer/WMSServer?request=GetLegendGraphic&version=1.0.0&format=image%2Fpng&layer=1"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
           }
         },
         "interfaceGroup": "Copernicus Land - CLCplus Backbone"
@@ -277,6 +288,13 @@
         "layers": "0",
         "zIndex": 2,
         "type": "wms"
+      },
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
+        },
+        "description": "Provides a pan-European spatially consistent and seamless, detailed land cover inventory for the 2018 reference year, for each polygon showing the dominant land cover among the 18 basic land cover classes and additional attributes. The minimum mapping unit of the dataset is 0.5 ha."
       }
     },
     {
@@ -284,7 +302,6 @@
       "isActive": false,
       "layout": {
         "layerCard": {
-          "description": "Provides detailed land cover and land use information for 55 thematic classes in selected Natura2000 sites for the 2018 reference year. The dataset has a Minimum Mapping Unit (MMU) of 0.5 ha and a Minimum Mapping Width (MMW) of 10 m and is available as vector data.",
           "toggleable": true,
           "controls": [
             "zoomToCenter"
@@ -293,10 +310,6 @@
             "type": "image",
             "visible": true,
             "data": "https://copernicus.discomap.eea.europa.eu/arcgis/services/Natura2000/N2K_2018/MapServer/WMSServer?request=GetLegendGraphic&version=1.0.0&format=image%2Fpng&layer=1"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
           }
         },
         "interfaceGroup": "Copernicus Land - Priority Areas - N2K"
@@ -306,6 +319,13 @@
         "layers": "0",
         "zIndex": 2,
         "type": "wms"
+      },
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
+        },
+        "description": "Provides detailed land cover and land use information for 55 thematic classes in selected Natura2000 sites for the 2018 reference year. The dataset has a Minimum Mapping Unit (MMU) of 0.5 ha and a Minimum Mapping Width (MMW) of 10 m and is available as vector data."
       }
     },
     {
@@ -313,7 +333,6 @@
       "isActive": false,
       "layout": {
         "layerCard": {
-          "description": "Provides detailed land cover and land use information for 55 thematic classes in selected Natura2000 sites for the 2012 reference year. The dataset has a Minimum Mapping Unit (MMU) of 0.5 ha and a Minimum Mapping Width (MMW) of 10 m and is available as vector data.",
           "toggleable": true,
           "controls": [
             "zoomToCenter"
@@ -322,10 +341,6 @@
             "type": "image",
             "visible": true,
             "data": "https://copernicus.discomap.eea.europa.eu/arcgis/services/Natura2000/N2K_2012/MapServer/WMSServer?request=GetLegendGraphic&version=1.0.0&format=image%2Fpng&layer=0"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
           }
         },
         "interfaceGroup": "Copernicus Land - Priority Areas - N2K"
@@ -335,6 +350,13 @@
         "layers": "0",
         "zIndex": 2,
         "type": "wms"
+      },
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
+        },
+        "description": "Provides detailed land cover and land use information for 55 thematic classes in selected Natura2000 sites for the 2012 reference year. The dataset has a Minimum Mapping Unit (MMU) of 0.5 ha and a Minimum Mapping Width (MMW) of 10 m and is available as vector data."
       }
     },
     {
@@ -342,7 +364,6 @@
       "isActive": false,
       "layout": {
         "layerCard": {
-          "description": "Provides detailed land cover and land use information for 55 thematic classes in selected Natura2000 sites for the 2006 reference year. The dataset has a Minimum Mapping Unit (MMU) of 0.5 ha and a Minimum Mapping Width (MMW) of 10 m and is available as vector data.",
           "toggleable": true,
           "controls": [
             "zoomToCenter"
@@ -351,10 +372,6 @@
             "type": "image",
             "visible": true,
             "data": "https://copernicus.discomap.eea.europa.eu/arcgis/services/Natura2000/N2K_2006/MapServer/WMSServer?request=GetLegendGraphic&version=1.0.0&format=image%2Fpng&layer=1"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
           }
         },
         "interfaceGroup": "Copernicus Land - Priority Areas - N2K"
@@ -364,6 +381,13 @@
         "layers": "0",
         "zIndex": 2,
         "type": "wms"
+      },
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
+        },
+        "description": "Provides detailed land cover and land use information for 55 thematic classes in selected Natura2000 sites for the 2006 reference year. The dataset has a Minimum Mapping Unit (MMU) of 0.5 ha and a Minimum Mapping Width (MMW) of 10 m and is available as vector data."
       }
     },
     {
@@ -371,7 +395,6 @@
       "isActive": false,
       "layout": {
         "layerCard": {
-          "description": "Provides information on land cover and land use changes for 55 thematic classes in selected Natura2000 sites between the 2012 and 2018 reference years. The dataset has a Minimum Mapping Unit (MMU) of 0.5 ha and a Minimum Mapping Width (MMW) of 10 m and is available as vector data.",
           "toggleable": true,
           "controls": [
             "zoomToCenter"
@@ -380,10 +403,6 @@
             "type": "image",
             "visible": true,
             "data": "https://copernicus.discomap.eea.europa.eu/arcgis/services/Natura2000/N2K_Change_2012_2018/MapServer/WMSServer?request=GetLegendGraphic&version=1.0.0&format=image%2Fpng&layer=1"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
           }
         },
         "interfaceGroup": "Copernicus Land - Priority Areas - N2K"
@@ -393,6 +412,13 @@
         "layers": "0",
         "zIndex": 2,
         "type": "wms"
+      },
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
+        },
+        "description": "Provides information on land cover and land use changes for 55 thematic classes in selected Natura2000 sites between the 2012 and 2018 reference years. The dataset has a Minimum Mapping Unit (MMU) of 0.5 ha and a Minimum Mapping Width (MMW) of 10 m and is available as vector data."
       }
     },
     {
@@ -400,7 +426,6 @@
       "isActive": false,
       "layout": {
         "layerCard": {
-          "description": "Provides information on land cover and land use changes for 55 thematic classes in selected Natura2000 sites between the 2006 and 2012 reference years. The dataset has a Minimum Mapping Unit (MMU) of 0.5 ha and a Minimum Mapping Width (MMW) of 10 m and is available as vector data.",
           "toggleable": true,
           "controls": [
             "zoomToCenter"
@@ -409,10 +434,6 @@
             "type": "image",
             "visible": true,
             "data": "https://copernicus.discomap.eea.europa.eu/arcgis/services/Natura2000/N2K_Change_2006_2012/MapServer/WMSServer?request=GetLegendGraphic&version=1.0.0&format=image%2Fpng&layer=1"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
           }
         },
         "interfaceGroup": "Copernicus Land - Priority Areas - N2K"
@@ -422,6 +443,13 @@
         "layers": "0",
         "zIndex": 2,
         "type": "wms"
+      },
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
+        },
+        "description": "Provides information on land cover and land use changes for 55 thematic classes in selected Natura2000 sites between the 2006 and 2012 reference years. The dataset has a Minimum Mapping Unit (MMU) of 0.5 ha and a Minimum Mapping Width (MMW) of 10 m and is available as vector data."
       }
     },
     {
@@ -429,7 +457,6 @@
       "isActive": false,
       "layout": {
         "layerCard": {
-          "description": "Provides at pan-European level in the spatial resolution of 10 m and 100 m a forest classification for three thematic classes (all non-forest areas / broadleaved forest / coniferous forest) with the agricultural/urban trees removed for the 2018 reference year.",
           "toggleable": true,
           "control": [
             "zoomToCenter"
@@ -437,10 +464,6 @@
           "legend": {
             "type": "image",
             "data": "https://land.copernicus.eu/en/products/high-resolution-layer-forest-type/map-legends/hrl_forest_type_2018_10m.jpg/@@images/image"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
           }
         },
         "interfaceGroup": "Copernicus Land - High Resolution Layer Forest Type"
@@ -450,6 +473,13 @@
         "layers": "HRL_ForestType_2018:FTY_MosaicSymbology",
         "zIndex": 2,
         "type": "wms"
+      },
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
+        },
+        "description": "Provides at pan-European level in the spatial resolution of 10 m and 100 m a forest classification for three thematic classes (all non-forest areas / broadleaved forest / coniferous forest) with the agricultural/urban trees removed for the 2018 reference year."
       }
     },
     {
@@ -457,7 +487,6 @@
       "isActive": false,
       "layout": {
         "layerCard": {
-          "description": "Provides at pan-European level in the spatial resolution of 20 m and 100 m a forest classification with three thematic classes (all non-forest areas / broadleaved forest / coniferous forest) for the 2015 reference year. In the 100 m spatial resolution the dataset has the agricultural/urban trees removed.",
           "toggleable": true,
           "control": [
             "zoomToCenter"
@@ -465,10 +494,6 @@
           "legend": {
             "type": "image",
             "data": "https://image.discomap.eea.europa.eu/arcgis/services/GioLandPublic/HRL_ForestType_2015/MapServer/WMSServer?request=GetLegendGraphic&version=1.0.0&format=image%2Fpng&layer=HRL_Forest_Type_2015_20m795"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
           }
         },
         "interfaceGroup": "Copernicus Land - High Resolution Layer Forest Type"
@@ -478,6 +503,13 @@
         "layers": "HRL_Forest_Type_2015_100m18936",
         "zIndex": 2,
         "type": "wms"
+      },
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
+        },
+        "description": "Provides at pan-European level in the spatial resolution of 20 m and 100 m a forest classification with three thematic classes (all non-forest areas / broadleaved forest / coniferous forest) for the 2015 reference year. In the 100 m spatial resolution the dataset has the agricultural/urban trees removed."
       }
     },
     {
@@ -485,7 +517,6 @@
       "isActive": false,
       "layout": {
         "layerCard": {
-          "description": "Provides at pan-European level in the spatial resolution of 20 m and 100 m a forest classification with three thematic classes (all non-forest areas / broadleaved forest / coniferous forest) for the 2012 reference year. In the 100 m spatial resolution the dataset has the agricultural/urban trees removed.",
           "toggleable": true,
           "control": [
             "zoomToCenter"
@@ -493,10 +524,6 @@
           "legend": {
             "type": "image",
             "data": "https://image.discomap.eea.europa.eu/arcgis/services/GioLandPublic/HRL_Forest_Cover_Type_2012/MapServer/WmsServer?request=GetLegendGraphic&version=1.0.0&format=image%2Fpng&layer=HRL_Forest_Type_2012_20m30052"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
           }
         },
         "interfaceGroup": "Copernicus Land - High Resolution Layer Forest Type"
@@ -506,6 +533,13 @@
         "layers": "HRL_Forest_Type_2012_100m1103",
         "zIndex": 2,
         "type": "wms"
+      },
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
+        },
+        "description": "Provides at pan-European level in the spatial resolution of 20 m and 100 m a forest classification with three thematic classes (all non-forest areas / broadleaved forest / coniferous forest) for the 2012 reference year. In the 100 m spatial resolution the dataset has the agricultural/urban trees removed."
       }
     },
     {
@@ -513,7 +547,6 @@
       "isActive": false,
       "layout": {
         "layerCard": {
-          "description": "Provides at pan-European level in the spatial resolution of 10 m and 100 m a basic land cover classification with two thematic classes (grassland / non-grassland) for the 2018 reference year.",
           "toggleable": true,
           "control": [
             "zoomToCenter"
@@ -521,10 +554,6 @@
           "legend": {
             "type": "image",
             "data": "https://land.copernicus.eu/en/products/high-resolution-layer-grassland/map-legends/hrl_grassland_2018_10m.jpg/@@images/image"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
           }
         },
         "interfaceGroup": "Copernicus Land - High Resolution Layer Grassland"
@@ -534,6 +563,13 @@
         "layers": "HRL_Grassland_2018",
         "zIndex": 2,
         "type": "wms"
+      },
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
+        },
+        "description": "Provides at pan-European level in the spatial resolution of 10 m and 100 m a basic land cover classification with two thematic classes (grassland / non-grassland) for the 2018 reference year."
       }
     },
     {
@@ -541,7 +577,6 @@
       "isActive": false,
       "layout": {
         "layerCard": {
-          "description": "Provides at pan-European level in the spatial resolution of 20 m and 100 m a basic land cover classification with two thematic classes (grassland / non-grassland) for the 2015 reference year.",
           "toggleable": true,
           "control": [
             "zoomToCenter"
@@ -549,10 +584,6 @@
           "legend": {
             "type": "image",
             "data": "https://image.discomap.eea.europa.eu/arcgis/services/GioLandPublic/HRL_Grassland_2015/MapServer/WMSServer?request=GetLegendGraphic&version=1.0.0&format=image%2Fpng&layer=1"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
           }
         },
         "interfaceGroup": "Copernicus Land - High Resolution Layer Grassland"
@@ -562,6 +593,13 @@
         "layers": "0",
         "zIndex": 2,
         "type": "wms"
+      },
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
+        },
+        "description": "Provides at pan-European level in the spatial resolution of 20 m and 100 m a basic land cover classification with two thematic classes (grassland / non-grassland) for the 2015 reference year."
       }
     },
     {
@@ -569,7 +607,6 @@
       "isActive": false,
       "layout": {
         "layerCard": {
-          "description": "Provides at pan-European level in the spatial resolution of 20 m information on changes in grassland vegetation cover between the 2105 and 2018 reference years.",
           "toggleable": true,
           "control": [
             "zoomToCenter"
@@ -577,10 +614,6 @@
           "legend": {
             "type": "image",
             "data": "https://land.copernicus.eu/en/products/high-resolution-layer-grassland/map-legends/hrl_grassland_cha_1518_20m.jpg/@@images/image"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
           }
         },
         "interfaceGroup": "Copernicus Land - High Resolution Layer Grassland"
@@ -590,6 +623,13 @@
         "layers": "HRL_GrasslandChange_15_18:GRAC_MosaicSymbology",
         "zIndex": 2,
         "type": "wms"
+      },
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
+        },
+        "description": "Provides at pan-European level in the spatial resolution of 20 m information on changes in grassland vegetation cover between the 2105 and 2018 reference years."
       }
     }
   ]

--- a/sef-ecosystems-biodiversity/config.json
+++ b/sef-ecosystems-biodiversity/config.json
@@ -66,7 +66,7 @@
           "legend": {
             "type": "image",
             "visible": true,
-            "data": "https://land.copernicus.eu/en/products/global-dynamic-land-cover/map-legends/single_class_forest.png/@@images/image-220-1d593b046e598a8ba51609a1bd8afa5c.png"
+            "url": "https://land.copernicus.eu/en/products/global-dynamic-land-cover/map-legends/single_class_forest.png/@@images/image-220-1d593b046e598a8ba51609a1bd8afa5c.png"
           }
         },
         "interfaceGroup": "Copernicus Land - Land Cover"
@@ -96,7 +96,7 @@
           "legend": {
             "type": "image",
             "visible": true,
-            "data": "https://land.copernicus.eu/en/products/global-dynamic-land-cover/map-legends/single_class_forest.png/@@images/image-220-1d593b046e598a8ba51609a1bd8afa5c.png"
+            "url": "https://land.copernicus.eu/en/products/global-dynamic-land-cover/map-legends/single_class_forest.png/@@images/image-220-1d593b046e598a8ba51609a1bd8afa5c.png"
           }
         },
         "interfaceGroup": "Copernicus Land - Land Cover"
@@ -126,7 +126,7 @@
           "legend": {
             "type": "image",
             "visible": true,
-            "data": "https://land.copernicus.eu/en/products/global-dynamic-land-cover/map-legends/single_class_forest.png/@@images/image-220-1d593b046e598a8ba51609a1bd8afa5c.png"
+            "url": "https://land.copernicus.eu/en/products/global-dynamic-land-cover/map-legends/single_class_forest.png/@@images/image-220-1d593b046e598a8ba51609a1bd8afa5c.png"
           }
         },
         "interfaceGroup": "Copernicus Land - Land Cover"
@@ -156,7 +156,7 @@
           "legend": {
             "type": "image",
             "visible": true,
-            "data": "https://land.copernicus.eu/en/products/global-dynamic-land-cover/map-legends/single_class_forest.png/@@images/image-220-1d593b046e598a8ba51609a1bd8afa5c.png"
+            "url": "https://land.copernicus.eu/en/products/global-dynamic-land-cover/map-legends/single_class_forest.png/@@images/image-220-1d593b046e598a8ba51609a1bd8afa5c.png"
           }
         },
         "interfaceGroup": "Copernicus Land - Land Cover"
@@ -186,7 +186,7 @@
           "legend": {
             "type": "image",
             "visible": true,
-            "data": "https://land.copernicus.eu/en/products/global-dynamic-land-cover/map-legends/single_class_forest.png/@@images/image-220-1d593b046e598a8ba51609a1bd8afa5c.png"
+            "url": "https://land.copernicus.eu/en/products/global-dynamic-land-cover/map-legends/single_class_forest.png/@@images/image-220-1d593b046e598a8ba51609a1bd8afa5c.png"
           }
         },
         "interfaceGroup": "Copernicus Land - Land Cover"
@@ -216,7 +216,7 @@
           "legend": {
             "type": "image",
             "visible": true,
-            "data": "https://land.copernicus.eu/en/products/clc-backbone/map-legends/clc-backbone-2018_raster-10-m.png/@@images/image"
+            "url": "https://land.copernicus.eu/en/products/clc-backbone/map-legends/clc-backbone-2018_raster-10-m.png/@@images/image"
           }
         },
         "interfaceGroup": "Copernicus Land - CLCplus Backbone"
@@ -247,7 +247,7 @@
           "legend": {
             "type": "image",
             "visible": true,
-            "data": "https://land.copernicus.eu/en/products/clc-backbone/map-legends/clc-backbone-2018_raster-10-m.png/@@images/image"
+            "url": "https://land.copernicus.eu/en/products/clc-backbone/map-legends/clc-backbone-2018_raster-10-m.png/@@images/image"
           }
         },
         "interfaceGroup": "Copernicus Land - CLCplus Backbone"
@@ -278,7 +278,7 @@
           "legend": {
             "type": "image",
             "visible": true,
-            "data": "https://copernicus.discomap.eea.europa.eu/arcgis/services/CLC_plus/CLCplus2018_WM/MapServer/WMSServer?request=GetLegendGraphic&version=1.0.0&format=image%2Fpng&layer=1"
+            "url": "https://copernicus.discomap.eea.europa.eu/arcgis/services/CLC_plus/CLCplus2018_WM/MapServer/WMSServer?request=GetLegendGraphic&version=1.0.0&format=image%2Fpng&layer=1"
           }
         },
         "interfaceGroup": "Copernicus Land - CLCplus Backbone"
@@ -309,7 +309,7 @@
           "legend": {
             "type": "image",
             "visible": true,
-            "data": "https://copernicus.discomap.eea.europa.eu/arcgis/services/Natura2000/N2K_2018/MapServer/WMSServer?request=GetLegendGraphic&version=1.0.0&format=image%2Fpng&layer=1"
+            "url": "https://copernicus.discomap.eea.europa.eu/arcgis/services/Natura2000/N2K_2018/MapServer/WMSServer?request=GetLegendGraphic&version=1.0.0&format=image%2Fpng&layer=1"
           }
         },
         "interfaceGroup": "Copernicus Land - Priority Areas - N2K"
@@ -340,7 +340,7 @@
           "legend": {
             "type": "image",
             "visible": true,
-            "data": "https://copernicus.discomap.eea.europa.eu/arcgis/services/Natura2000/N2K_2012/MapServer/WMSServer?request=GetLegendGraphic&version=1.0.0&format=image%2Fpng&layer=0"
+            "url": "https://copernicus.discomap.eea.europa.eu/arcgis/services/Natura2000/N2K_2012/MapServer/WMSServer?request=GetLegendGraphic&version=1.0.0&format=image%2Fpng&layer=0"
           }
         },
         "interfaceGroup": "Copernicus Land - Priority Areas - N2K"
@@ -371,7 +371,7 @@
           "legend": {
             "type": "image",
             "visible": true,
-            "data": "https://copernicus.discomap.eea.europa.eu/arcgis/services/Natura2000/N2K_2006/MapServer/WMSServer?request=GetLegendGraphic&version=1.0.0&format=image%2Fpng&layer=1"
+            "url": "https://copernicus.discomap.eea.europa.eu/arcgis/services/Natura2000/N2K_2006/MapServer/WMSServer?request=GetLegendGraphic&version=1.0.0&format=image%2Fpng&layer=1"
           }
         },
         "interfaceGroup": "Copernicus Land - Priority Areas - N2K"
@@ -402,7 +402,7 @@
           "legend": {
             "type": "image",
             "visible": true,
-            "data": "https://copernicus.discomap.eea.europa.eu/arcgis/services/Natura2000/N2K_Change_2012_2018/MapServer/WMSServer?request=GetLegendGraphic&version=1.0.0&format=image%2Fpng&layer=1"
+            "url": "https://copernicus.discomap.eea.europa.eu/arcgis/services/Natura2000/N2K_Change_2012_2018/MapServer/WMSServer?request=GetLegendGraphic&version=1.0.0&format=image%2Fpng&layer=1"
           }
         },
         "interfaceGroup": "Copernicus Land - Priority Areas - N2K"
@@ -433,7 +433,7 @@
           "legend": {
             "type": "image",
             "visible": true,
-            "data": "https://copernicus.discomap.eea.europa.eu/arcgis/services/Natura2000/N2K_Change_2006_2012/MapServer/WMSServer?request=GetLegendGraphic&version=1.0.0&format=image%2Fpng&layer=1"
+            "url": "https://copernicus.discomap.eea.europa.eu/arcgis/services/Natura2000/N2K_Change_2006_2012/MapServer/WMSServer?request=GetLegendGraphic&version=1.0.0&format=image%2Fpng&layer=1"
           }
         },
         "interfaceGroup": "Copernicus Land - Priority Areas - N2K"
@@ -463,7 +463,7 @@
           ],
           "legend": {
             "type": "image",
-            "data": "https://land.copernicus.eu/en/products/high-resolution-layer-forest-type/map-legends/hrl_forest_type_2018_10m.jpg/@@images/image"
+            "url": "https://land.copernicus.eu/en/products/high-resolution-layer-forest-type/map-legends/hrl_forest_type_2018_10m.jpg/@@images/image"
           }
         },
         "interfaceGroup": "Copernicus Land - High Resolution Layer Forest Type"
@@ -493,7 +493,7 @@
           ],
           "legend": {
             "type": "image",
-            "data": "https://image.discomap.eea.europa.eu/arcgis/services/GioLandPublic/HRL_ForestType_2015/MapServer/WMSServer?request=GetLegendGraphic&version=1.0.0&format=image%2Fpng&layer=HRL_Forest_Type_2015_20m795"
+            "url": "https://image.discomap.eea.europa.eu/arcgis/services/GioLandPublic/HRL_ForestType_2015/MapServer/WMSServer?request=GetLegendGraphic&version=1.0.0&format=image%2Fpng&layer=HRL_Forest_Type_2015_20m795"
           }
         },
         "interfaceGroup": "Copernicus Land - High Resolution Layer Forest Type"
@@ -523,7 +523,7 @@
           ],
           "legend": {
             "type": "image",
-            "data": "https://image.discomap.eea.europa.eu/arcgis/services/GioLandPublic/HRL_Forest_Cover_Type_2012/MapServer/WmsServer?request=GetLegendGraphic&version=1.0.0&format=image%2Fpng&layer=HRL_Forest_Type_2012_20m30052"
+            "url": "https://image.discomap.eea.europa.eu/arcgis/services/GioLandPublic/HRL_Forest_Cover_Type_2012/MapServer/WmsServer?request=GetLegendGraphic&version=1.0.0&format=image%2Fpng&layer=HRL_Forest_Type_2012_20m30052"
           }
         },
         "interfaceGroup": "Copernicus Land - High Resolution Layer Forest Type"
@@ -553,7 +553,7 @@
           ],
           "legend": {
             "type": "image",
-            "data": "https://land.copernicus.eu/en/products/high-resolution-layer-grassland/map-legends/hrl_grassland_2018_10m.jpg/@@images/image"
+            "url": "https://land.copernicus.eu/en/products/high-resolution-layer-grassland/map-legends/hrl_grassland_2018_10m.jpg/@@images/image"
           }
         },
         "interfaceGroup": "Copernicus Land - High Resolution Layer Grassland"
@@ -583,7 +583,7 @@
           ],
           "legend": {
             "type": "image",
-            "data": "https://image.discomap.eea.europa.eu/arcgis/services/GioLandPublic/HRL_Grassland_2015/MapServer/WMSServer?request=GetLegendGraphic&version=1.0.0&format=image%2Fpng&layer=1"
+            "url": "https://image.discomap.eea.europa.eu/arcgis/services/GioLandPublic/HRL_Grassland_2015/MapServer/WMSServer?request=GetLegendGraphic&version=1.0.0&format=image%2Fpng&layer=1"
           }
         },
         "interfaceGroup": "Copernicus Land - High Resolution Layer Grassland"
@@ -613,7 +613,7 @@
           ],
           "legend": {
             "type": "image",
-            "data": "https://land.copernicus.eu/en/products/high-resolution-layer-grassland/map-legends/hrl_grassland_cha_1518_20m.jpg/@@images/image"
+            "url": "https://land.copernicus.eu/en/products/high-resolution-layer-grassland/map-legends/hrl_grassland_cha_1518_20m.jpg/@@images/image"
           }
         },
         "interfaceGroup": "Copernicus Land - High Resolution Layer Grassland"

--- a/sef-food/config.json
+++ b/sef-food/config.json
@@ -29,19 +29,22 @@
       "data": {
         "url": "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
         "type": "xyz",
-        "zIndex": 0
+        "zIndex": 0,
+        "isBaseLayer": true
       }
     },
     {
       "name": "Geo Service - Labels",
       "isActive": false,
+      "meta": {
+        "attribution": {
+          "text": "EOC Basemap Map Service",
+          "url": "https://geoservice.dlr.de/web/"
+        }
+      },
       "layout": {
         "layerCard": {
-          "toggleable": true,
-          "attribution": {
-            "text": "EOC Basemap Map Service",
-            "url": "https://geoservice.dlr.de/web/"
-          }
+          "toggleable": true
         },
         "interfaceGroup": "Basemaps"
       },
@@ -58,17 +61,19 @@
     {
       "name": "Maize 2021",
       "isActive": false,
+      "meta": {
+        "description": "WorldCereal maize, globally, at 10m resolution in specific seasons throughout the year.",
+        "attribution": {
+          "text": "WorldCereal",
+          "url": "https://esa-worldcereal.org/"
+        }
+      },
       "layout": {
         "layerCard": {
-          "description": "WorldCereal maize, globally, at 10m resolution in specific seasons throughout the year.",
           "toggleable": true,
           "controls": [
             "zoomToCenter"
-          ],
-          "attribution": {
-            "text": "WorldCereal",
-            "url": "https://esa-worldcereal.org/"
-          }
+          ]
         },
         "interfaceGroup": "WorldCereal"
       },
@@ -82,17 +87,19 @@
     {
       "name": "Spring Cereals 2021",
       "isActive": false,
+      "meta": {
+        "description": "WorldCereal spring cereals, globally, at 10m resolution in specific seasons throughout the year.",
+        "attribution": {
+          "text": "WorldCereal",
+          "url": "https://esa-worldcereal.org/"
+        }
+      },
       "layout": {
         "layerCard": {
-          "description": "WorldCereal spring cereals, globally, at 10m resolution in specific seasons throughout the year.",
           "toggleable": true,
           "controls": [
             "zoomToCenter"
-          ],
-          "attribution": {
-            "text": "WorldCereal",
-            "url": "https://esa-worldcereal.org/"
-          }
+          ]
         },
         "interfaceGroup": "WorldCereal"
       },
@@ -106,17 +113,19 @@
     {
       "name": "Temporary Crops 2021",
       "isActive": false,
+      "meta": {
+        "description": "Pixel-based, binary classification product at 10m spatial resolution distinguishing annual cropland from all other types of land cover. Annual cropland is defined according to the JECAM 2018 definition, in short: A piece of land that is sowed/planted and harvestable at least once within the 12 months after the sowing/planting date. The annual cropland produces an herbaceous cover which should reach a coverage of 30% and can be combined with some tree or woody vegetation not exceeding a coverage of 20%. Exception 1: Sugarcane and cassava, although perennial crops, are explicitly included. Exception 2: Frequently harvested, annual and/or perennial fodder crops such as grasslands and alfalfa are explicitly excluded. Exception 3: Greenhouse crops are excluded. This product is generated within one month after the end of the main growing season and looks back one year in time.",
+        "attribution": {
+          "text": "WorldCereal",
+          "url": "https://esa-worldcereal.org/"
+        }
+      },
       "layout": {
         "layerCard": {
-          "description": "Pixel-based, binary classification product at 10m spatial resolution distinguishing annual cropland from all other types of land cover. Annual cropland is defined according to the JECAM 2018 definition, in short: A piece of land that is sowed/planted and harvestable at least once within the 12 months after the sowing/planting date. The annual cropland produces an herbaceous cover which should reach a coverage of 30% and can be combined with some tree or woody vegetation not exceeding a coverage of 20%. Exception 1: Sugarcane and cassava, although perennial crops, are explicitly included. Exception 2: Frequently harvested, annual and/or perennial fodder crops such as grasslands and alfalfa are explicitly excluded. Exception 3: Greenhouse crops are excluded. This product is generated within one month after the end of the main growing season and looks back one year in time.",
           "toggleable": true,
           "controls": [
             "zoomToCenter"
-          ],
-          "attribution": {
-            "text": "WorldCereal",
-            "url": "https://esa-worldcereal.org/"
-          }
+          ]
         },
         "interfaceGroup": "WorldCereal"
       },
@@ -130,17 +139,19 @@
     {
       "name": "Winter Cereals 2021",
       "isActive": false,
+      "meta": {
+        "description": "WorldCereal winter cereals, globally, at 10m resolution in specific seasons throughout the year.",
+        "attribution": {
+          "text": "WorldCereal",
+          "url": "https://esa-worldcereal.org/"
+        }
+      },
       "layout": {
         "layerCard": {
-          "description": "WorldCereal winter cereals, globally, at 10m resolution in specific seasons throughout the year.",
           "toggleable": true,
           "controls": [
             "zoomToCenter"
-          ],
-          "attribution": {
-            "text": "WorldCereal",
-            "url": "https://esa-worldcereal.org/"
-          }
+          ]
         },
         "interfaceGroup": "WorldCereal"
       },
@@ -155,67 +166,6 @@
       "name": "WorldCover 2020",
       "isActive": false,
       "layout": {
-        "layerCard": {
-          "description": "Land cover map for 2020",
-          "toggleable": true,
-          "controls": [
-            "zoomToCenter"
-          ],
-          "legend": {
-            "type": "swatch",
-            "visible": true,
-            "data": [
-              {
-                "color": "rgb(0, 100, 0)",
-                "label": "Tree cover"
-              },
-              {
-                "color": "rgb(255, 187, 34)",
-                "label": "Shrubland"
-              },
-              {
-                "color": "rgb(255, 255, 76)",
-                "label": "Grassland"
-              },
-              {
-                "color": "rgb(240, 150, 255)",
-                "label": "Cropland"
-              },
-              {
-                "color": "rgb(255, 0, 0)",
-                "label": "Built up"
-              },
-              {
-                "color": "rgb(180, 180, 180)",
-                "label": "Bare"
-              },
-              {
-                "color": "rgb(240, 240, 240)",
-                "label": "Snow and ice"
-              },
-              {
-                "color": "rgb(0, 100, 200)",
-                "label": "Permanent water bodies"
-              },
-              {
-                "color": "rgb(0, 150, 160)",
-                "label": "Herbaceous wetland"
-              },
-              {
-                "color": "rgb(0, 207, 117)",
-                "label": "Mangroves"
-              },
-              {
-                "color": "rgb(250, 230, 160)",
-                "label": "Moss and lichen"
-              }
-            ]
-          },
-          "attribution": {
-            "text": "WorldCover",
-            "url": "https://esa-worldcover.org/"
-          }
-        },
         "interfaceGroup": "WorldCover"
       },
       "data": {
@@ -223,71 +173,126 @@
         "layers": "WORLDCOVER_2020_MAP",
         "zIndex": 2,
         "type": "wms"
+      },
+      "meta": {
+        "attribution": {
+          "text": "WorldCover",
+          "url": "https://esa-worldcover.org/"
+        },
+        "description": "Land cover map for 2020",
+        "categories": [
+          {
+            "color": "rgb(0, 100, 0)",
+            "label": "Tree cover"
+          },
+          {
+            "color": "rgb(255, 187, 34)",
+            "label": "Shrubland"
+          },
+          {
+            "color": "rgb(255, 255, 76)",
+            "label": "Grassland"
+          },
+          {
+            "color": "rgb(240, 150, 255)",
+            "label": "Cropland"
+          },
+          {
+            "color": "rgb(255, 0, 0)",
+            "label": "Built up"
+          },
+          {
+            "color": "rgb(180, 180, 180)",
+            "label": "Bare"
+          },
+          {
+            "color": "rgb(240, 240, 240)",
+            "label": "Snow and ice"
+          },
+          {
+            "color": "rgb(0, 100, 200)",
+            "label": "Permanent water bodies"
+          },
+          {
+            "color": "rgb(0, 150, 160)",
+            "label": "Herbaceous wetland"
+          },
+          {
+            "color": "rgb(0, 207, 117)",
+            "label": "Mangroves"
+          },
+          {
+            "color": "rgb(250, 230, 160)",
+            "label": "Moss and lichen"
+          }
+        ]
       }
     },
     {
       "name": "WorldCover 2021",
       "isActive": false,
+      "meta": {
+        "description": "Land cover map for 2021",
+        "attribution": {
+          "text": "WorldCover",
+          "url": "https://esa-worldcover.org/"
+        },
+        "categories": [
+          {
+            "color": "rgb(0, 100, 0)",
+            "label": "Tree cover"
+          },
+          {
+            "color": "rgb(255, 187, 34)",
+            "label": "Shrubland"
+          },
+          {
+            "color": "rgb(255, 255, 76)",
+            "label": "Grassland"
+          },
+          {
+            "color": "rgb(240, 150, 255)",
+            "label": "Cropland"
+          },
+          {
+            "color": "rgb(255, 0, 0)",
+            "label": "Built up"
+          },
+          {
+            "color": "rgb(180, 180, 180)",
+            "label": "Bare"
+          },
+          {
+            "color": "rgb(240, 240, 240)",
+            "label": "Snow and ice"
+          },
+          {
+            "color": "rgb(0, 100, 200)",
+            "label": "Permanent water bodies"
+          },
+          {
+            "color": "rgb(0, 150, 160)",
+            "label": "Herbaceous wetland"
+          },
+          {
+            "color": "rgb(0, 207, 117)",
+            "label": "Mangroves"
+          },
+          {
+            "color": "rgb(250, 230, 160)",
+            "label": "Moss and lichen"
+          }
+        ]
+      },
       "layout": {
         "layerCard": {
-          "description": "Land cover map for 2021",
           "toggleable": true,
           "controls": [
             "zoomToCenter"
           ],
           "legend": {
             "type": "swatch",
-            "visible": true,
-            "data": [
-              {
-                "color": "rgb(0, 100, 0)",
-                "label": "Tree cover"
-              },
-              {
-                "color": "rgb(255, 187, 34)",
-                "label": "Shrubland"
-              },
-              {
-                "color": "rgb(255, 255, 76)",
-                "label": "Grassland"
-              },
-              {
-                "color": "rgb(240, 150, 255)",
-                "label": "Cropland"
-              },
-              {
-                "color": "rgb(255, 0, 0)",
-                "label": "Built up"
-              },
-              {
-                "color": "rgb(180, 180, 180)",
-                "label": "Bare"
-              },
-              {
-                "color": "rgb(240, 240, 240)",
-                "label": "Snow and ice"
-              },
-              {
-                "color": "rgb(0, 100, 200)",
-                "label": "Permanent water bodies"
-              },
-              {
-                "color": "rgb(0, 150, 160)",
-                "label": "Herbaceous wetland"
-              },
-              {
-                "color": "rgb(0, 207, 117)",
-                "label": "Mangroves"
-              },
-              {
-                "color": "rgb(250, 230, 160)",
-                "label": "Moss and lichen"
-              }
-            ]
-          },
-          "attribution": {
-            "text": "WorldCover",
-            "url": "https://esa-worldcover.org/"
+            "visible": true
           }
         },
         "interfaceGroup": "WorldCover"
@@ -302,14 +307,16 @@
     {
       "name": "Sentinel-2 RGB Composite 2020",
       "isActive": false,
+      "meta": {
+        "description": "Natural color image made from images in blue, green and red. Median composite for 2020.",
+        "attribution": {
+          "text": "WorldCover",
+          "url": "https://esa-worldcover.org/"
+        }
+      },
       "layout": {
         "layerCard": {
-          "toggleable": true,
-          "description": "Natural color image made from images in blue, green and red. Median composite for 2020.",
-          "attribution": {
-            "text": "WorldCover",
-            "url": "https://esa-worldcover.org/"
-          }
+          "toggleable": true
         },
         "interfaceGroup": "WorldCover"
       },
@@ -323,14 +330,16 @@
     {
       "name": "Sentinel-2 RGB Composite 2021",
       "isActive": false,
+      "meta": {
+        "description": "Natural color image made from images in blue, green and red. Median composite for 2021.",
+        "attribution": {
+          "text": "WorldCover",
+          "url": "https://esa-worldcover.org/"
+        }
+      },
       "layout": {
         "layerCard": {
-          "toggleable": true,
-          "description": "Natural color image made from images in blue, green and red. Median composite for 2021.",
-          "attribution": {
-            "text": "WorldCover",
-            "url": "https://esa-worldcover.org/"
-          }
+          "toggleable": true
         },
         "interfaceGroup": "WorldCover"
       },
@@ -345,10 +354,7 @@
       "name": "Sentinel-2 RGB vs WorldCover (2020)",
       "isActive": false,
       "layout": {
-        "interfaceGroup": "WorldCover",
-        "layerCard": {
-          "toggleable": true
-        }
+        "interfaceGroup": "WorldCover"
       },
       "data": {
         "type": "swipe",
@@ -357,16 +363,14 @@
           "Sentinel-2 RGB Composite 2020",
           "Geo Service - Labels"
         ]
-      }
+      },
+      "meta": {}
     },
     {
       "name": "Sentinel-2 RGB vs WorldCover (2021)",
       "isActive": false,
       "layout": {
-        "interfaceGroup": "WorldCover",
-        "layerCard": {
-          "toggleable": true
-        }
+        "interfaceGroup": "WorldCover"
       },
       "data": {
         "type": "swipe",
@@ -375,18 +379,25 @@
           "Sentinel-2 RGB Composite 2021",
           "Geo Service - Labels"
         ]
-      }
+      },
+      "meta": {}
     },
     {
       "name": "WorldSoils",
       "isActive": false,
+      "meta": {
+        "attribution": {
+          "text": "WorldCover",
+          "url": "https://world-soils.com/"
+        },
+        "startColor": "rgb(10,10,40)",
+        "endColor": "rgb(173,216,230)",
+        "min": 22,
+        "max": 5344
+      },
       "layout": {
         "layerCard": {
-          "toggleable": true,
-          "attribution": {
-            "text": "WorldCover",
-            "url": "https://world-soils.com/"
-          }
+          "toggleable": true
         },
         "interfaceGroup": "WORLDSOILS"
       },
@@ -399,98 +410,82 @@
           {
             "url": "https://eoresults.esa.int/d/APEX_TEST/2020/03/01/europe_aggr-orgc_00-020_mean_100_202003-202210/europe_aggr-orgc_00-020_mean_100_202003-202210.tif"
           }
-        ],
-        "style": {
-          "color": [
-            "interpolate",
-            [
-              "linear"
-            ],
-            [
-              "band",
-              1
-            ],
-            0,
-            "rgba(0, 0, 0, 0)",
-            22,
-            "rgb(10,10,40)",
-            5344,
-            "rgb(173,216,230)"
-          ]
-        }
+        ]
       }
     },
     {
       "name": "Copernicus DEM",
       "isActive": false,
+      "meta": {
+        "description": "Global evelation model at 30m resolution.",
+        "attribution": {
+          "text": "TerraScope",
+          "url": "https://terrascope.be/"
+        },
+        "categories": [
+          {
+            "color": "rgba(33,10,240,89)",
+            "label": "-200"
+          },
+          {
+            "color": "rgba(19,30,255,89)",
+            "label": "0"
+          },
+          {
+            "color": "rgba(229,252,178,255)",
+            "label": "50"
+          },
+          {
+            "color": "rgba(203,230,132,255)",
+            "label": "150"
+          },
+          {
+            "color": "rgba(84,185,61,255)",
+            "label": "300"
+          },
+          {
+            "color": "rgba(12,140,54,255)",
+            "label": "700"
+          },
+          {
+            "color": "rgba(80,143,58,255)",
+            "label": "1000"
+          },
+          {
+            "color": "rgba(239,182,13,255)",
+            "label": "2000"
+          },
+          {
+            "color": "rgba(169,42,2,255)",
+            "label": "4000"
+          },
+          {
+            "color": "rgba(116,23,5,255)",
+            "label": "5000"
+          },
+          {
+            "color": "rgba(112,55,21,255)",
+            "label": "6000"
+          },
+          {
+            "color": "rgba(179,179,179,255)",
+            "label": "7000"
+          },
+          {
+            "color": "rgba(235,233,235,255)",
+            "label": "8000"
+          }
+        ]
+      },
       "layout": {
         "layerCard": {
-          "description": "Global evelation model at 30m resolution.",
           "toggleable": true,
           "controls": [
             "zoomToCenter"
           ],
           "legend": {
             "type": "swatch",
-            "visible": true,
-            "data": [
-              {
-                "color": "rgba(33,10,240,89)",
-                "label": "-200"
-              },
-              {
-                "color": "rgba(19,30,255,89)",
-                "label": "0"
-              },
-              {
-                "color": "rgba(229,252,178,255)",
-                "label": "50"
-              },
-              {
-                "color": "rgba(203,230,132,255)",
-                "label": "150"
-              },
-              {
-                "color": "rgba(84,185,61,255)",
-                "label": "300"
-              },
-              {
-                "color": "rgba(12,140,54,255)",
-                "label": "700"
-              },
-              {
-                "color": "rgba(80,143,58,255)",
-                "label": "1000"
-              },
-              {
-                "color": "rgba(239,182,13,255)",
-                "label": "2000"
-              },
-              {
-                "color": "rgba(169,42,2,255)",
-                "label": "4000"
-              },
-              {
-                "color": "rgba(116,23,5,255)",
-                "label": "5000"
-              },
-              {
-                "color": "rgba(112,55,21,255)",
-                "label": "6000"
-              },
-              {
-                "color": "rgba(179,179,179,255)",
-                "label": "7000"
-              },
-              {
-                "color": "rgba(235,233,235,255)",
-                "label": "8000"
-              }
-            ]
-          },
-          "attribution": {
-            "text": "TerraScope",
-            "url": "https://terrascope.be/"
+            "visible": true
           }
         },
         "interfaceGroup": "Digital Elevation Models"
@@ -505,9 +500,15 @@
     {
       "name": "Vegetation Land Cover 2019 (raster 100m), global, yearly - version 3",
       "isActive": false,
+      "meta": {
+        "description": "Provides at global level spatial information on different types (classes) of physical coverage of the Earth's surface, e.g. forests, grasslands, croplands, lakes, wetlands for the 2019 base year. The data are updated annually and are available for the 2015-2019 years.",
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
+        }
+      },
       "layout": {
         "layerCard": {
-          "description": "Provides at global level spatial information on different types (classes) of physical coverage of the Earth's surface, e.g. forests, grasslands, croplands, lakes, wetlands for the 2019 base year. The data are updated annually and are available for the 2015-2019 years.",
           "toggleable": true,
           "controls": [
             "zoomToCenter"
@@ -515,11 +516,7 @@
           "legend": {
             "type": "image",
             "visible": true,
-            "data": "https://land.copernicus.eu/en/products/global-dynamic-land-cover/map-legends/cropland.png/@@images/image-42-24528c9e1f2a59287dfdc41c1cce703f.png"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
+            "url": "https://land.copernicus.eu/en/products/global-dynamic-land-cover/map-legends/cropland.png/@@images/image-42-24528c9e1f2a59287dfdc41c1cce703f.png"
           }
         },
         "interfaceGroup": "Copernicus Land - Land Cover"
@@ -533,23 +530,14 @@
     {
       "name": "Vegetation Land Cover 2018 (raster 100m), global, yearly - version 3",
       "isActive": false,
-      "layout": {
-        "layerCard": {
-          "description": "Provides at global level spatial information on different types (classes) of physical coverage of the Earth's surface, e.g. forests, grasslands, croplands, lakes, wetlands for the 2018 base year. The data are updated annually and are available for the 2015-2019 years.",
-          "toggleable": true,
-          "controls": [
-            "zoomToCenter"
-          ],
-          "legend": {
-            "type": "image",
-            "visible": true,
-            "data": "https://land.copernicus.eu/en/products/global-dynamic-land-cover/map-legends/cropland.png/@@images/image-42-24528c9e1f2a59287dfdc41c1cce703f.png"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
-          }
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
         },
+        "description": "Provides at global level spatial information on different types (classes) of physical coverage of the Earth's surface, e.g. forests, grasslands, croplands, lakes, wetlands for the 2018 base year. The data are updated annually and are available for the 2015-2019 years."
+      },
+      "layout": {
         "interfaceGroup": "Copernicus Land - Land Cover"
       },
       "data": {
@@ -561,9 +549,15 @@
     {
       "name": "Vegetation Land Cover 2017 (raster 100m), global, yearly - version 3",
       "isActive": false,
+      "meta": {
+        "description": "Provides at global level spatial information on different types (classes) of physical coverage of the Earth's surface, e.g. forests, grasslands, croplands, lakes, wetlands for the 2017 base year. The data are updated annually and are available for the 2015-2019 years.",
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
+        }
+      },
       "layout": {
         "layerCard": {
-          "description": "Provides at global level spatial information on different types (classes) of physical coverage of the Earth's surface, e.g. forests, grasslands, croplands, lakes, wetlands for the 2017 base year. The data are updated annually and are available for the 2015-2019 years.",
           "toggleable": true,
           "controls": [
             "zoomToCenter"
@@ -571,11 +565,7 @@
           "legend": {
             "type": "image",
             "visible": true,
-            "data": "https://land.copernicus.eu/en/products/global-dynamic-land-cover/map-legends/cropland.png/@@images/image-42-24528c9e1f2a59287dfdc41c1cce703f.png"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
+            "url": "https://land.copernicus.eu/en/products/global-dynamic-land-cover/map-legends/cropland.png/@@images/image-42-24528c9e1f2a59287dfdc41c1cce703f.png"
           }
         },
         "interfaceGroup": "Copernicus Land - Land Cover"
@@ -589,23 +579,14 @@
     {
       "name": "Vegetation Land Cover 2016 (raster 100m), global, yearly - version 3",
       "isActive": false,
-      "layout": {
-        "layerCard": {
-          "description": "Provides at global level spatial information on different types (classes) of physical coverage of the Earth's surface, e.g. forests, grasslands, croplands, lakes, wetlands for the 2016 base year. The data are updated annually and are available for the 2015-2019 years.",
-          "toggleable": true,
-          "controls": [
-            "zoomToCenter"
-          ],
-          "legend": {
-            "type": "image",
-            "visible": true,
-            "data": "https://land.copernicus.eu/en/products/global-dynamic-land-cover/map-legends/cropland.png/@@images/image-42-24528c9e1f2a59287dfdc41c1cce703f.png"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
-          }
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
         },
+        "description": "Provides at global level spatial information on different types (classes) of physical coverage of the Earth's surface, e.g. forests, grasslands, croplands, lakes, wetlands for the 2016 base year. The data are updated annually and are available for the 2015-2019 years."
+      },
+      "layout": {
         "interfaceGroup": "Copernicus Land - Land Cover"
       },
       "data": {
@@ -617,23 +598,14 @@
     {
       "name": "VegetationLand Cover 2015 (raster 100m), global, yearly - version 3",
       "isActive": false,
-      "layout": {
-        "layerCard": {
-          "description": "Provides at global level spatial information on different types (classes) of physical coverage of the Earth's surface, e.g. forests, grasslands, croplands, lakes, wetlands for the 2015 base year. The data are updated annually and are available for the 2015-2019 years.",
-          "toggleable": true,
-          "controls": [
-            "zoomToCenter"
-          ],
-          "legend": {
-            "type": "image",
-            "visible": true,
-            "data": "https://land.copernicus.eu/en/products/global-dynamic-land-cover/map-legends/cropland.png/@@images/image-42-24528c9e1f2a59287dfdc41c1cce703f.png"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
-          }
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
         },
+        "description": "Provides at global level spatial information on different types (classes) of physical coverage of the Earth's surface, e.g. forests, grasslands, croplands, lakes, wetlands for the 2015 base year. The data are updated annually and are available for the 2015-2019 years."
+      },
+      "layout": {
         "interfaceGroup": "Copernicus Land - Land Cover"
       },
       "data": {
@@ -645,23 +617,14 @@
     {
       "name": "Surface Soil Moisture 2014-present (raster 1km), Europe, daily - version 1",
       "isActive": false,
-      "layout": {
-        "layerCard": {
-          "description": "Provides information on the relative water content of the top few centimeters soil, describing how wet or dry the soil is in its topmost layer, expressed in percent saturation. Daily observations are available for the continental Europe in the spatial resolution of 1 km and with the temporal extent from October 2014 to present.",
-          "toggleable": true,
-          "controls": [
-            "zoomToCenter"
-          ],
-          "legend": {
-            "type": "image",
-            "visible": true,
-            "data": "https://land.copernicus.eu/en/products/soil-moisture/legends/legacy-legends/smlegend.png/@@images/image"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
-          }
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
         },
+        "description": "Provides information on the relative water content of the top few centimeters soil, describing how wet or dry the soil is in its topmost layer, expressed in percent saturation. Daily observations are available for the continental Europe in the spatial resolution of 1 km and with the temporal extent from October 2014 to present."
+      },
+      "layout": {
         "interfaceGroup": "Copernicus Land - Soil Moisture"
       },
       "data": {
@@ -674,23 +637,14 @@
     {
       "name": "Soil Water Index 2015-present (raster 1 km), Europe, daily – version 1",
       "isActive": false,
-      "layout": {
-        "layerCard": {
-          "description": "Quantifies the moisture condition at various depths in the soil. Daily observations are available for the continental Europe in the spatial resolution of 1 km and with the temporal extent from January 2015 to present.",
-          "toggleable": true,
-          "controls": [
-            "zoomToCenter"
-          ],
-          "legend": {
-            "type": "image",
-            "visible": true,
-            "data": "https://land.copernicus.eu/en/products/soil-moisture/legends/legacy-legends/smlegend.png/@@images/image"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
-          }
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
         },
+        "description": "Quantifies the moisture condition at various depths in the soil. Daily observations are available for the continental Europe in the spatial resolution of 1 km and with the temporal extent from January 2015 to present."
+      },
+      "layout": {
         "interfaceGroup": "Copernicus Land - Soil Moisture"
       },
       "data": {
@@ -703,23 +657,14 @@
     {
       "name": "Soil Water Index 2007-present (raster 12.5 km), global, daily – version 3",
       "isActive": false,
-      "layout": {
-        "layerCard": {
-          "description": "Provides daily updates on the moisture conditions in different soil layers. The data are available over the globe at the spatial resolution of 0.1° and with the temporal extent from January 2007 to present.",
-          "toggleable": true,
-          "controls": [
-            "zoomToCenter"
-          ],
-          "legend": {
-            "type": "image",
-            "visible": true,
-            "data": "https://land.copernicus.eu/en/products/soil-moisture/legends/legacy-legends/smlegend.png/@@images/image"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
-          }
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
         },
+        "description": "Provides daily updates on the moisture conditions in different soil layers. The data are available over the globe at the spatial resolution of 0.1° and with the temporal extent from January 2007 to present."
+      },
+      "layout": {
         "interfaceGroup": "Copernicus Land - Soil Moisture"
       },
       "data": {
@@ -732,23 +677,14 @@
     {
       "name": "Soil Water Index 2007-present (raster 12.5 km), global, 10-daily – version 3",
       "isActive": false,
-      "layout": {
-        "layerCard": {
-          "description": "Averages the daily Soil Water Index product over 10 days. The data are produced every 10 days over the globe at the spatial resolution of 0.1° and with the temporal extent from January 2007 to present.",
-          "toggleable": true,
-          "controls": [
-            "zoomToCenter"
-          ],
-          "legend": {
-            "type": "image",
-            "visible": true,
-            "data": "https://land.copernicus.eu/en/products/soil-moisture/legends/legacy-legends/smlegend.png/@@images/image"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
-          }
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
         },
+        "description": "Averages the daily Soil Water Index product over 10 days. The data are produced every 10 days over the globe at the spatial resolution of 0.1° and with the temporal extent from January 2007 to present."
+      },
+      "layout": {
         "interfaceGroup": "Copernicus Land - Soil Moisture"
       },
       "data": {
@@ -761,23 +697,14 @@
     {
       "name": "Fraction of Green Vegetation Cover 2014-present (raster 300 m), global, 10-daily – version 1",
       "isActive": false,
-      "layout": {
-        "layerCard": {
-          "description": "Corresponds to the fraction of ground covered by green vegetation. It quantifies the spatial extent of the vegetation. Every 10-days estimates are available in near real time at global scale in the spatial resolution of about 300 m from January 2014 to June 2020 based upon PROBA-V data with version 1.0 and from July 2020 onwards based upon Sentinel-3/OLCI data with version 1.1.",
-          "toggleable": true,
-          "control": [
-            "zoomToCenter"
-          ],
-          "legend": {
-            "type": "image",
-            "visible": true,
-            "data": "https://land.copernicus.eu/en/products/vegetation/legends/legacy-legends/fcover_300m-1km-v1-v2.png/@@images/image"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
-          }
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
         },
+        "description": "Corresponds to the fraction of ground covered by green vegetation. It quantifies the spatial extent of the vegetation. Every 10-days estimates are available in near real time at global scale in the spatial resolution of about 300 m from January 2014 to June 2020 based upon PROBA-V data with version 1.0 and from July 2020 onwards based upon Sentinel-3/OLCI data with version 1.1."
+      },
+      "layout": {
         "interfaceGroup": "Copernicus Land - Vegetation"
       },
       "data": {
@@ -790,23 +717,14 @@
     {
       "name": "Fraction of Green Vegetation Cover 1999-2020 (raster 1 km), global, 10-daily – version 1",
       "isActive": false,
-      "layout": {
-        "layerCard": {
-          "description": "Corresponds to the fraction of ground covered by green vegetation. It quantifies the spatial extent of the vegetation. Every 10-days estimates are available at global scale in the spatial resolution of about 1 km covering the period from 1999 to May 2014 in version 1.4 from SPOT/VEGETATION data and from June 2014 to June 2020 in version 1.5 from PROBA-V data.",
-          "toggleable": true,
-          "control": [
-            "zoomToCenter"
-          ],
-          "legend": {
-            "type": "image",
-            "visible": true,
-            "data": "https://land.copernicus.eu/en/products/vegetation/legends/legacy-legends/fcover.png/@@images/image"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
-          }
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
         },
+        "description": "Corresponds to the fraction of ground covered by green vegetation. It quantifies the spatial extent of the vegetation. Every 10-days estimates are available at global scale in the spatial resolution of about 1 km covering the period from 1999 to May 2014 in version 1.4 from SPOT/VEGETATION data and from June 2014 to June 2020 in version 1.5 from PROBA-V data."
+      },
+      "layout": {
         "interfaceGroup": "Copernicus Land - Vegetation"
       },
       "data": {
@@ -819,23 +737,14 @@
     {
       "name": "Fraction of Green Vegetation Cover 1999-2020 (raster 1 km), global, 10-daily – version 2",
       "isActive": false,
-      "layout": {
-        "layerCard": {
-          "description": "Corresponds to the fraction of ground covered by green vegetation. It quantifies the spatial extent of the vegetation. Every 10-days estimates are available at global scale in the spatial resolution of about 1 km covering the period from 1999 to June 2020 from SPOT/VEGETATION and PROBA-V data.",
-          "toggleable": true,
-          "control": [
-            "zoomToCenter"
-          ],
-          "legend": {
-            "type": "image",
-            "visible": true,
-            "data": "https://land.copernicus.eu/en/products/vegetation/legends/legacy-legends/fcover_300m-1km-v1-v2.png/@@images/image"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
-          }
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
         },
+        "description": "Corresponds to the fraction of ground covered by green vegetation. It quantifies the spatial extent of the vegetation. Every 10-days estimates are available at global scale in the spatial resolution of about 1 km covering the period from 1999 to June 2020 from SPOT/VEGETATION and PROBA-V data."
+      },
+      "layout": {
         "interfaceGroup": "Copernicus Land - Vegetation"
       },
       "data": {
@@ -848,23 +757,14 @@
     {
       "name": "Fraction of Absorbed Photosynthetically Active Radiation 2016-present (raster 10 m), Europe, daily",
       "isActive": false,
-      "layout": {
-        "layerCard": {
-          "description": "Provides at pan-European level and in near real time daily updates of the fraction of the solar radiation absorbed by live leaves for the photosynthesis activity. The data are available at 10 m x 10 m spatial resolution with the temporal extent from October 2016 to present.",
-          "toggleable": true,
-          "control": [
-            "zoomToCenter"
-          ],
-          "legend": {
-            "type": "image",
-            "visible": true,
-            "data": "https://land.copernicus.eu/en/products/vegetation/legends/hrvpp-legends/legend_fapar.png/@@images/image"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
-          }
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
         },
+        "description": "Provides at pan-European level and in near real time daily updates of the fraction of the solar radiation absorbed by live leaves for the photosynthesis activity. The data are available at 10 m x 10 m spatial resolution with the temporal extent from October 2016 to present."
+      },
+      "layout": {
         "interfaceGroup": "Copernicus Land - Vegetation"
       },
       "data": {
@@ -877,23 +777,14 @@
     {
       "name": "Fraction of Absorbed Photosynthetically Active Radiation 2014-present (raster 300 m), global, 10-daily – version 1",
       "isActive": false,
-      "layout": {
-        "layerCard": {
-          "description": "Quantifies the fraction of the solar radiation absorbed by live plants for photosynthesis. Every 10-days estimates are available in near real time at global scale in the spatial resolution of about 300 m from January 2014 to June 2020 based upon PROBA-V data with version 1.0 and from July 2020 onwards based upon Sentinel-3/OLCI data with version 1.1.",
-          "toggleable": true,
-          "control": [
-            "zoomToCenter"
-          ],
-          "legend": {
-            "type": "image",
-            "visible": true,
-            "data": "https://land.copernicus.eu/en/products/vegetation/legends/legacy-legends/clms_global_fapar_300m_v1_10daily.png/@@images/image"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
-          }
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
         },
+        "description": "Quantifies the fraction of the solar radiation absorbed by live plants for photosynthesis. Every 10-days estimates are available in near real time at global scale in the spatial resolution of about 300 m from January 2014 to June 2020 based upon PROBA-V data with version 1.0 and from July 2020 onwards based upon Sentinel-3/OLCI data with version 1.1."
+      },
+      "layout": {
         "interfaceGroup": "Copernicus Land - Vegetation"
       },
       "data": {
@@ -906,23 +797,14 @@
     {
       "name": "Fraction of Absorbed Photosynthetically Active Radiation 1999-2020 (raster 1 km), global, 10-daily – version 1",
       "isActive": false,
-      "layout": {
-        "layerCard": {
-          "description": "Quantifies the fraction of the solar radiation absorbed by live plants for photosynthesis. Every 10-days estimates are available at global scale in the spatial resolution of about 1 km covering the period from 1999 to May 2014 in version 1.4 from SPOT/VEGETATION data and from June 2014 to June 2020 in version 1.5 from PROBA-V data.",
-          "toggleable": true,
-          "control": [
-            "zoomToCenter"
-          ],
-          "legend": {
-            "type": "image",
-            "visible": true,
-            "data": "https://land.copernicus.eu/en/products/vegetation/legends/legacy-legends/clms_global_fapar_1km_v1_10daily.png/@@images/image"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
-          }
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
         },
+        "description": "Quantifies the fraction of the solar radiation absorbed by live plants for photosynthesis. Every 10-days estimates are available at global scale in the spatial resolution of about 1 km covering the period from 1999 to May 2014 in version 1.4 from SPOT/VEGETATION data and from June 2014 to June 2020 in version 1.5 from PROBA-V data."
+      },
+      "layout": {
         "interfaceGroup": "Copernicus Land - Vegetation"
       },
       "data": {
@@ -935,23 +817,14 @@
     {
       "name": "Fraction of Absorbed Photosynthetically Active Radiation 1999-2020 (raster 1 km), global, 10-daily – version 2",
       "isActive": false,
-      "layout": {
-        "layerCard": {
-          "description": "Quantifies the fraction of the solar radiation absorbed by live plants for photosynthesis. Every 10-days estimates are available at global scale in the spatial resolution of about 1 km covering the period from 1999 to June 2020 from SPOT/VEGETATION and PROBA-V data.",
-          "toggleable": true,
-          "control": [
-            "zoomToCenter"
-          ],
-          "legend": {
-            "type": "image",
-            "visible": true,
-            "data": "https://land.copernicus.eu/en/products/vegetation/legends/legacy-legends/clms_global_fapar_1km_v2_10daily.png/@@images/image"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
-          }
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
         },
+        "description": "Quantifies the fraction of the solar radiation absorbed by live plants for photosynthesis. Every 10-days estimates are available at global scale in the spatial resolution of about 1 km covering the period from 1999 to June 2020 from SPOT/VEGETATION and PROBA-V data."
+      },
+      "layout": {
         "interfaceGroup": "Copernicus Land - Vegetation"
       },
       "data": {
@@ -964,23 +837,14 @@
     {
       "name": "Leaf Area Index 2016-present (raster 10 m), Europe, daily",
       "isActive": false,
-      "layout": {
-        "layerCard": {
-          "description": "Defined as half of the total area of green elements of the canopy per unit horizontal ground area daily updates of Leaf Area Index are provided at pan-European level and in near real time. The data are available at 10 m x 10 m spatial resolution with the temporal extent from October 2016 to present.",
-          "toggleable": true,
-          "control": [
-            "zoomToCenter"
-          ],
-          "legend": {
-            "type": "image",
-            "visible": true,
-            "data": "https://land.copernicus.eu/en/products/vegetation/legends/hrvpp-legends/lailegend.png/@@images/image"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
-          }
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
         },
+        "description": "Defined as half of the total area of green elements of the canopy per unit horizontal ground area daily updates of Leaf Area Index are provided at pan-European level and in near real time. The data are available at 10 m x 10 m spatial resolution with the temporal extent from October 2016 to present."
+      },
+      "layout": {
         "interfaceGroup": "Copernicus Land - Vegetation"
       },
       "data": {
@@ -993,23 +857,14 @@
     {
       "name": "Leaf Area Index 2014-present (raster 300 m), global, 10-daily – version 1",
       "isActive": false,
-      "layout": {
-        "layerCard": {
-          "description": "Defined as half the total area of green elements of the canopy per unit horizontal ground area. Every 10-days estimates are available in near real time at global scale in the spatial resolution of about 300 m from January 2014 to June 2020 based upon PROBA-V data with version 1.0 and from July 2020 onwards based upon Sentinel-3/OLCI data with version 1.1.",
-          "toggleable": true,
-          "control": [
-            "zoomToCenter"
-          ],
-          "legend": {
-            "type": "image",
-            "visible": true,
-            "data": "https://land.copernicus.eu/en/products/vegetation/legends/legacy-legends/leafareaindexlegend-300m-1km-v1-v2.png/@@images/image"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
-          }
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
         },
+        "description": "Defined as half the total area of green elements of the canopy per unit horizontal ground area. Every 10-days estimates are available in near real time at global scale in the spatial resolution of about 300 m from January 2014 to June 2020 based upon PROBA-V data with version 1.0 and from July 2020 onwards based upon Sentinel-3/OLCI data with version 1.1."
+      },
+      "layout": {
         "interfaceGroup": "Copernicus Land - Vegetation"
       },
       "data": {
@@ -1022,23 +877,14 @@
     {
       "name": "Leaf Area Index 1999-2020 (raster 1 km), global, 10-daily – version 1",
       "isActive": false,
-      "layout": {
-        "layerCard": {
-          "description": "Defined as half the total area of green elements of the canopy per unit horizontal ground area. Every 10-days estimates are available at global scale in the spatial resolution of about 1 km covering the period from 1999 to May 2014 in version 1.4 from SPOT/VEGETATION data and from June 2014 to June 2020 in version 1.5 from PROBA-V data.",
-          "toggleable": true,
-          "control": [
-            "zoomToCenter"
-          ],
-          "legend": {
-            "type": "image",
-            "visible": true,
-            "data": "https://land.copernicus.eu/en/products/vegetation/legends/legacy-legends/lailegend.png/@@images/image"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
-          }
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
         },
+        "description": "Defined as half the total area of green elements of the canopy per unit horizontal ground area. Every 10-days estimates are available at global scale in the spatial resolution of about 1 km covering the period from 1999 to May 2014 in version 1.4 from SPOT/VEGETATION data and from June 2014 to June 2020 in version 1.5 from PROBA-V data."
+      },
+      "layout": {
         "interfaceGroup": "Copernicus Land - Vegetation"
       },
       "data": {
@@ -1051,23 +897,14 @@
     {
       "name": "Leaf Area Index 1999-2020 (raster 1 km), global, 10-daily – version 2",
       "isActive": false,
-      "layout": {
-        "layerCard": {
-          "description": "Defined as half the total area of green elements of the canopy per unit horizontal ground area. Every 10-days estimates are available at global scale in the spatial resolution of about 1 km covering the period from 1999 to June 2020 from SPOT/VEGETATION and PROBA-V data.",
-          "toggleable": true,
-          "control": [
-            "zoomToCenter"
-          ],
-          "legend": {
-            "type": "image",
-            "visible": true,
-            "data": "https://land.copernicus.eu/en/products/vegetation/legends/legacy-legends/leafareaindexlegend-300m-1km-v1-v2.png/@@images/image"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
-          }
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
         },
+        "description": "Defined as half the total area of green elements of the canopy per unit horizontal ground area. Every 10-days estimates are available at global scale in the spatial resolution of about 1 km covering the period from 1999 to June 2020 from SPOT/VEGETATION and PROBA-V data."
+      },
+      "layout": {
         "interfaceGroup": "Copernicus Land - Vegetation"
       },
       "data": {
@@ -1080,22 +917,14 @@
     {
       "name": "Forest Type 2018 (raster 10 m and 100 m), Europe, 3-yearly",
       "isActive": false,
-      "layout": {
-        "layerCard": {
-          "description": "Provides at pan-European level in the spatial resolution of 10 m and 100 m a forest classification for three thematic classes (all non-forest areas / broadleaved forest / coniferous forest) with the agricultural/urban trees removed for the 2018 reference year.",
-          "toggleable": true,
-          "control": [
-            "zoomToCenter"
-          ],
-          "legend": {
-            "type": "image",
-            "data": "https://land.copernicus.eu/en/products/high-resolution-layer-forest-type/map-legends/hrl_forest_type_2018_10m.jpg/@@images/image"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
-          }
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
         },
+        "description": "Provides at pan-European level in the spatial resolution of 10 m and 100 m a forest classification for three thematic classes (all non-forest areas / broadleaved forest / coniferous forest) with the agricultural/urban trees removed for the 2018 reference year."
+      },
+      "layout": {
         "interfaceGroup": "Copernicus Land - High Resolution Layer Forest Type"
       },
       "data": {
@@ -1108,22 +937,14 @@
     {
       "name": "Forest Type 2015 (raster 20 m and 100 m), Europe, 3-yearly",
       "isActive": false,
-      "layout": {
-        "layerCard": {
-          "description": "Provides at pan-European level in the spatial resolution of 20 m and 100 m a forest classification with three thematic classes (all non-forest areas / broadleaved forest / coniferous forest) for the 2015 reference year. In the 100 m spatial resolution the dataset has the agricultural/urban trees removed.",
-          "toggleable": true,
-          "control": [
-            "zoomToCenter"
-          ],
-          "legend": {
-            "type": "image",
-            "data": "https://image.discomap.eea.europa.eu/arcgis/services/GioLandPublic/HRL_ForestType_2015/MapServer/WMSServer?request=GetLegendGraphic&version=1.0.0&format=image%2Fpng&layer=HRL_Forest_Type_2015_20m795"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
-          }
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
         },
+        "description": "Provides at pan-European level in the spatial resolution of 20 m and 100 m a forest classification with three thematic classes (all non-forest areas / broadleaved forest / coniferous forest) for the 2015 reference year. In the 100 m spatial resolution the dataset has the agricultural/urban trees removed."
+      },
+      "layout": {
         "interfaceGroup": "Copernicus Land - High Resolution Layer Forest Type"
       },
       "data": {
@@ -1136,22 +957,14 @@
     {
       "name": "Forest Type 2012 (raster 20 m and 100 m), Europe, 3-yearly",
       "isActive": false,
-      "layout": {
-        "layerCard": {
-          "description": "Provides at pan-European level in the spatial resolution of 20 m and 100 m a forest classification with three thematic classes (all non-forest areas / broadleaved forest / coniferous forest) for the 2012 reference year. In the 100 m spatial resolution the dataset has the agricultural/urban trees removed.",
-          "toggleable": true,
-          "control": [
-            "zoomToCenter"
-          ],
-          "legend": {
-            "type": "image",
-            "data": "https://image.discomap.eea.europa.eu/arcgis/services/GioLandPublic/HRL_Forest_Cover_Type_2012/MapServer/WmsServer?request=GetLegendGraphic&version=1.0.0&format=image%2Fpng&layer=HRL_Forest_Type_2012_20m30052"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
-          }
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
         },
+        "description": "Provides at pan-European level in the spatial resolution of 20 m and 100 m a forest classification with three thematic classes (all non-forest areas / broadleaved forest / coniferous forest) for the 2012 reference year. In the 100 m spatial resolution the dataset has the agricultural/urban trees removed."
+      },
+      "layout": {
         "interfaceGroup": "Copernicus Land - High Resolution Layer Forest Type"
       },
       "data": {
@@ -1164,23 +977,14 @@
     {
       "name": "Normalised Difference Vegetation Index 2016-present (raster 10 m), Europe, daily",
       "isActive": false,
-      "layout": {
-        "layerCard": {
-          "description": "Describes the difference between visible and near infrared reflectance of vegetation cover. Daily updates of Normalised Difference Vegetation Index are provided at pan-European level and in near real time. The data are available at 10 m x 10 m spatial resolution with the temporal extent from October 2016 to present.",
-          "toggleable": true,
-          "control": [
-            "zoomToCenter"
-          ],
-          "legend": {
-            "type": "image",
-            "visible": true,
-            "data": "https://land.copernicus.eu/en/products/vegetation/legends/hrvpp-legends/legend_ndvi.png/@@images/image"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
-          }
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
         },
+        "description": "Describes the difference between visible and near infrared reflectance of vegetation cover. Daily updates of Normalised Difference Vegetation Index are provided at pan-European level and in near real time. The data are available at 10 m x 10 m spatial resolution with the temporal extent from October 2016 to present."
+      },
+      "layout": {
         "interfaceGroup": "Copernicus Land - Vegetation"
       },
       "data": {
@@ -1193,23 +997,14 @@
     {
       "name": "Normalised Difference Vegetation Index 2014-2020 (raster 300 m), global, 10-daily – version 1",
       "isActive": false,
-      "layout": {
-        "layerCard": {
-          "description": "NDVI is an indicator of the greenness of the biomes. Every 10-days estimates are available at global scale in the spatial resolution of about 300 m from 2014 to June 2020.",
-          "toggleable": true,
-          "control": [
-            "zoomToCenter"
-          ],
-          "legend": {
-            "type": "image",
-            "visible": true,
-            "data": "https://land.copernicus.eu/en/products/vegetation/legends/legacy-legends/ndvi.png/@@images/image"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
-          }
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
         },
+        "description": "NDVI is an indicator of the greenness of the biomes. Every 10-days estimates are available at global scale in the spatial resolution of about 300 m from 2014 to June 2020."
+      },
+      "layout": {
         "interfaceGroup": "Copernicus Land - Vegetation"
       },
       "data": {
@@ -1222,23 +1017,14 @@
     {
       "name": "Normalised Difference Vegetation Index 2020-present (raster 300 m), global, 10-daily – version 2",
       "isActive": false,
-      "layout": {
-        "layerCard": {
-          "description": "NDVI is an indicator of the greenness of the biomes. Every 10-days estimates are available in near real time at global scale in the spatial resolution of about 300 m from July 2020 to the present.",
-          "toggleable": true,
-          "control": [
-            "zoomToCenter"
-          ],
-          "legend": {
-            "type": "image",
-            "visible": true,
-            "data": "https://land.copernicus.eu/en/products/vegetation/legends/legacy-legends/ndvi.png/@@images/image"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
-          }
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
         },
+        "description": "NDVI is an indicator of the greenness of the biomes. Every 10-days estimates are available in near real time at global scale in the spatial resolution of about 300 m from July 2020 to the present."
+      },
+      "layout": {
         "interfaceGroup": "Copernicus Land - Vegetation"
       },
       "data": {
@@ -1251,23 +1037,14 @@
     {
       "name": "Normalised Difference Vegetation Index 1998-2020 (raster 1 km), global, 10-daily – version 2",
       "isActive": false,
-      "layout": {
-        "layerCard": {
-          "description": "NDVI is an indicator of the greenness of the biomes. Every 10-days estimates are available at global scale in the spatial resolution of about 1 km from April 1998 to 2013 based upon SPOT/VEGETATION data and from 2014 to 2020 based upon PROBA-V data.",
-          "toggleable": true,
-          "control": [
-            "zoomToCenter"
-          ],
-          "legend": {
-            "type": "image",
-            "visible": true,
-            "data": "https://land.copernicus.eu/en/products/vegetation/legends/legacy-legends/ndvi.png/@@images/image"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
-          }
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
         },
+        "description": "NDVI is an indicator of the greenness of the biomes. Every 10-days estimates are available at global scale in the spatial resolution of about 1 km from April 1998 to 2013 based upon SPOT/VEGETATION data and from 2014 to 2020 based upon PROBA-V data."
+      },
+      "layout": {
         "interfaceGroup": "Copernicus Land - Vegetation"
       },
       "data": {
@@ -1280,23 +1057,14 @@
     {
       "name": "Normalised Difference Vegetation Index 1999-2020 (raster 1 km), global, 10-daily – version 3",
       "isActive": false,
-      "layout": {
-        "layerCard": {
-          "description": "NDVI is an indicator of the greenness of the biomes. Every 10-days estimates are available at global scale in the spatial resolution of about 1 km from 1999 to 2013 based upon SPOT/VEGETATION data and from 2014 to June 2020 based upon PROBA-V data.",
-          "toggleable": true,
-          "control": [
-            "zoomToCenter"
-          ],
-          "legend": {
-            "type": "image",
-            "visible": true,
-            "data": "https://land.copernicus.eu/en/products/vegetation/legends/legacy-legends/ndvi.png/@@images/image"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
-          }
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
         },
+        "description": "NDVI is an indicator of the greenness of the biomes. Every 10-days estimates are available at global scale in the spatial resolution of about 1 km from 1999 to 2013 based upon SPOT/VEGETATION data and from 2014 to June 2020 based upon PROBA-V data."
+      },
+      "layout": {
         "interfaceGroup": "Copernicus Land - Vegetation"
       },
       "data": {
@@ -1309,23 +1077,14 @@
     {
       "name": "Normalised Difference Vegetation Index (Long Term Statistics) 1999-2017 (raster 1 km), global, 10-daily – version 2",
       "isActive": false,
-      "layout": {
-        "layerCard": {
-          "description": "Based upon SPOT/VEGETATION and PROBA-V NDVI 1km version 2, long-term statistics include the minimum, median, maximum, mean, standard deviation and the number of observations over the 19-years period 1999-2017.",
-          "toggleable": true,
-          "control": [
-            "zoomToCenter"
-          ],
-          "legend": {
-            "type": "image",
-            "visible": true,
-            "data": "https://land.copernicus.eu/en/products/vegetation/legends/legacy-legends/ndvi.png/@@images/image"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
-          }
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
         },
+        "description": "Based upon SPOT/VEGETATION and PROBA-V NDVI 1km version 2, long-term statistics include the minimum, median, maximum, mean, standard deviation and the number of observations over the 19-years period 1999-2017."
+      },
+      "layout": {
         "interfaceGroup": "Copernicus Land - Vegetation"
       },
       "data": {
@@ -1338,23 +1097,14 @@
     {
       "name": "Normalised Difference Vegetation Index (Long Term Statistics) 1999-2019 (raster 1 km), global, 10-daily – version 3",
       "isActive": false,
-      "layout": {
-        "layerCard": {
-          "description": "Based upon SPOT/VEGETATION and PROBA-V NDVI 1km version 3, long-term statistics include the minimum, median, maximum, mean, standard deviation and the number of observations over the 21-years period 1999-2019.\n",
-          "toggleable": true,
-          "control": [
-            "zoomToCenter"
-          ],
-          "legend": {
-            "type": "image",
-            "visible": true,
-            "data": "https://land.copernicus.eu/en/products/vegetation/legends/legacy-legends/ndvi.png/@@images/image"
-          },
-          "attribution": {
-            "text": "Copernicus Land Monitoring Service",
-            "url": "https://land.copernicus.eu/en"
-          }
+      "meta": {
+        "attribution": {
+          "text": "Copernicus Land Monitoring Service",
+          "url": "https://land.copernicus.eu/en"
         },
+        "description": "Based upon SPOT/VEGETATION and PROBA-V NDVI 1km version 3, long-term statistics include the minimum, median, maximum, mean, standard deviation and the number of observations over the 21-years period 1999-2019.\n"
+      },
+      "layout": {
         "interfaceGroup": "Copernicus Land - Vegetation"
       },
       "data": {

--- a/sef-food/config.json
+++ b/sef-food/config.json
@@ -44,7 +44,10 @@
       },
       "layout": {
         "layerCard": {
-          "toggleable": true
+          "toggleable": true,
+          "controls": [
+            "zoomToCenter"
+          ]
         },
         "interfaceGroup": "Basemaps"
       },
@@ -166,6 +169,16 @@
       "name": "WorldCover 2020",
       "isActive": false,
       "layout": {
+        "layerCard": {
+          "toggleable": true,
+          "controls": [
+            "zoomToCenter"
+          ],
+          "legend": {
+            "type": "swatch",
+            "visible": true
+          }
+        },
         "interfaceGroup": "WorldCover"
       },
       "data": {
@@ -339,7 +352,10 @@
       },
       "layout": {
         "layerCard": {
-          "toggleable": true
+          "toggleable": true,
+          "controls": [
+            "zoomToCenter"
+          ]
         },
         "interfaceGroup": "WorldCover"
       },
@@ -354,6 +370,12 @@
       "name": "Sentinel-2 RGB vs WorldCover (2020)",
       "isActive": false,
       "layout": {
+        "layerCard": {
+          "toggleable": true,
+          "controls": [
+            "zoomToCenter"
+          ]
+        },
         "interfaceGroup": "WorldCover"
       },
       "data": {
@@ -370,6 +392,12 @@
       "name": "Sentinel-2 RGB vs WorldCover (2021)",
       "isActive": false,
       "layout": {
+        "layerCard": {
+          "toggleable": true,
+          "controls": [
+            "zoomToCenter"
+          ]
+        },
         "interfaceGroup": "WorldCover"
       },
       "data": {
@@ -397,7 +425,10 @@
       },
       "layout": {
         "layerCard": {
-          "toggleable": true
+          "toggleable": true,
+          "controls": [
+            "zoomToCenter"
+          ]
         },
         "interfaceGroup": "WORLDSOILS"
       },
@@ -538,6 +569,17 @@
         "description": "Provides at global level spatial information on different types (classes) of physical coverage of the Earth's surface, e.g. forests, grasslands, croplands, lakes, wetlands for the 2018 base year. The data are updated annually and are available for the 2015-2019 years."
       },
       "layout": {
+        "layerCard": {
+          "toggleable": true,
+          "controls": [
+            "zoomToCenter"
+          ],
+          "legend": {
+            "type": "image",
+            "visible": true,
+            "url": "https://land.copernicus.eu/en/products/global-dynamic-land-cover/map-legends/cropland.png/@@images/image-42-24528c9e1f2a59287dfdc41c1cce703f.png"
+          }
+        },
         "interfaceGroup": "Copernicus Land - Land Cover"
       },
       "data": {
@@ -587,6 +629,17 @@
         "description": "Provides at global level spatial information on different types (classes) of physical coverage of the Earth's surface, e.g. forests, grasslands, croplands, lakes, wetlands for the 2016 base year. The data are updated annually and are available for the 2015-2019 years."
       },
       "layout": {
+        "layerCard": {
+          "toggleable": true,
+          "controls": [
+            "zoomToCenter"
+          ],
+          "legend": {
+            "type": "image",
+            "visible": true,
+            "url": "https://land.copernicus.eu/en/products/global-dynamic-land-cover/map-legends/cropland.png/@@images/image-42-24528c9e1f2a59287dfdc41c1cce703f.png"
+          }
+        },
         "interfaceGroup": "Copernicus Land - Land Cover"
       },
       "data": {
@@ -606,6 +659,17 @@
         "description": "Provides at global level spatial information on different types (classes) of physical coverage of the Earth's surface, e.g. forests, grasslands, croplands, lakes, wetlands for the 2015 base year. The data are updated annually and are available for the 2015-2019 years."
       },
       "layout": {
+        "layerCard": {
+          "toggleable": true,
+          "controls": [
+            "zoomToCenter"
+          ],
+          "legend": {
+            "type": "image",
+            "visible": true,
+            "url": "https://land.copernicus.eu/en/products/global-dynamic-land-cover/map-legends/cropland.png/@@images/image-42-24528c9e1f2a59287dfdc41c1cce703f.png"
+          }
+        },
         "interfaceGroup": "Copernicus Land - Land Cover"
       },
       "data": {
@@ -625,6 +689,17 @@
         "description": "Provides information on the relative water content of the top few centimeters soil, describing how wet or dry the soil is in its topmost layer, expressed in percent saturation. Daily observations are available for the continental Europe in the spatial resolution of 1 km and with the temporal extent from October 2014 to present."
       },
       "layout": {
+        "layerCard": {
+          "toggleable": true,
+          "controls": [
+            "zoomToCenter"
+          ],
+          "legend": {
+            "type": "image",
+            "visible": true,
+            "url": "https://land.copernicus.eu/en/products/soil-moisture/legends/legacy-legends/smlegend.png/@@images/image"
+          }
+        },
         "interfaceGroup": "Copernicus Land - Soil Moisture"
       },
       "data": {
@@ -645,6 +720,17 @@
         "description": "Quantifies the moisture condition at various depths in the soil. Daily observations are available for the continental Europe in the spatial resolution of 1 km and with the temporal extent from January 2015 to present."
       },
       "layout": {
+        "layerCard": {
+          "toggleable": true,
+          "controls": [
+            "zoomToCenter"
+          ],
+          "legend": {
+            "type": "image",
+            "visible": true,
+            "url": "https://land.copernicus.eu/en/products/soil-moisture/legends/legacy-legends/smlegend.png/@@images/image"
+          }
+        },
         "interfaceGroup": "Copernicus Land - Soil Moisture"
       },
       "data": {
@@ -665,6 +751,17 @@
         "description": "Provides daily updates on the moisture conditions in different soil layers. The data are available over the globe at the spatial resolution of 0.1° and with the temporal extent from January 2007 to present."
       },
       "layout": {
+        "layerCard": {
+          "toggleable": true,
+          "controls": [
+            "zoomToCenter"
+          ],
+          "legend": {
+            "type": "image",
+            "visible": true,
+            "url": "https://land.copernicus.eu/en/products/soil-moisture/legends/legacy-legends/smlegend.png/@@images/image"
+          }
+        },
         "interfaceGroup": "Copernicus Land - Soil Moisture"
       },
       "data": {
@@ -685,6 +782,17 @@
         "description": "Averages the daily Soil Water Index product over 10 days. The data are produced every 10 days over the globe at the spatial resolution of 0.1° and with the temporal extent from January 2007 to present."
       },
       "layout": {
+        "layerCard": {
+          "toggleable": true,
+          "controls": [
+            "zoomToCenter"
+          ],
+          "legend": {
+            "type": "image",
+            "visible": true,
+            "url": "https://land.copernicus.eu/en/products/soil-moisture/legends/legacy-legends/smlegend.png/@@images/image"
+          }
+        },
         "interfaceGroup": "Copernicus Land - Soil Moisture"
       },
       "data": {
@@ -705,6 +813,17 @@
         "description": "Corresponds to the fraction of ground covered by green vegetation. It quantifies the spatial extent of the vegetation. Every 10-days estimates are available in near real time at global scale in the spatial resolution of about 300 m from January 2014 to June 2020 based upon PROBA-V data with version 1.0 and from July 2020 onwards based upon Sentinel-3/OLCI data with version 1.1."
       },
       "layout": {
+        "layerCard": {
+          "toggleable": true,
+          "controls": [
+            "zoomToCenter"
+          ],
+          "legend": {
+            "type": "image",
+            "visible": true,
+            "url": "https://land.copernicus.eu/en/products/vegetation/legends/legacy-legends/fcover_300m-1km-v1-v2.png/@@images/image"
+          }
+        },
         "interfaceGroup": "Copernicus Land - Vegetation"
       },
       "data": {
@@ -725,6 +844,17 @@
         "description": "Corresponds to the fraction of ground covered by green vegetation. It quantifies the spatial extent of the vegetation. Every 10-days estimates are available at global scale in the spatial resolution of about 1 km covering the period from 1999 to May 2014 in version 1.4 from SPOT/VEGETATION data and from June 2014 to June 2020 in version 1.5 from PROBA-V data."
       },
       "layout": {
+        "layerCard": {
+          "toggleable": true,
+          "controls": [
+            "zoomToCenter"
+          ],
+          "legend": {
+            "type": "image",
+            "visible": true,
+            "url": "https://land.copernicus.eu/en/products/vegetation/legends/legacy-legends/fcover_300m-1km-v1-v2.png/@@images/image"
+          }
+        },
         "interfaceGroup": "Copernicus Land - Vegetation"
       },
       "data": {
@@ -745,6 +875,12 @@
         "description": "Corresponds to the fraction of ground covered by green vegetation. It quantifies the spatial extent of the vegetation. Every 10-days estimates are available at global scale in the spatial resolution of about 1 km covering the period from 1999 to June 2020 from SPOT/VEGETATION and PROBA-V data."
       },
       "layout": {
+        "layerCard": {
+          "toggleable": true,
+          "controls": [
+            "zoomToCenter"
+          ]
+        },
         "interfaceGroup": "Copernicus Land - Vegetation"
       },
       "data": {
@@ -765,6 +901,17 @@
         "description": "Provides at pan-European level and in near real time daily updates of the fraction of the solar radiation absorbed by live leaves for the photosynthesis activity. The data are available at 10 m x 10 m spatial resolution with the temporal extent from October 2016 to present."
       },
       "layout": {
+        "layerCard": {
+          "toggleable": true,
+          "controls": [
+            "zoomToCenter"
+          ],
+          "legend": {
+            "type": "image",
+            "visible": true,
+            "url": "https://land.copernicus.eu/en/products/vegetation/legends/hrvpp-legends/legend_fapar.png/@@images/image"
+          }
+        },
         "interfaceGroup": "Copernicus Land - Vegetation"
       },
       "data": {
@@ -785,6 +932,17 @@
         "description": "Quantifies the fraction of the solar radiation absorbed by live plants for photosynthesis. Every 10-days estimates are available in near real time at global scale in the spatial resolution of about 300 m from January 2014 to June 2020 based upon PROBA-V data with version 1.0 and from July 2020 onwards based upon Sentinel-3/OLCI data with version 1.1."
       },
       "layout": {
+        "layerCard": {
+          "toggleable": true,
+          "controls": [
+            "zoomToCenter"
+          ],
+          "legend": {
+            "type": "image",
+            "visible": true,
+            "url": "https://land.copernicus.eu/en/products/vegetation/legends/legacy-legends/clms_global_fapar_300m_v1_10daily.png/@@images/image"
+          }
+        },
         "interfaceGroup": "Copernicus Land - Vegetation"
       },
       "data": {
@@ -805,6 +963,17 @@
         "description": "Quantifies the fraction of the solar radiation absorbed by live plants for photosynthesis. Every 10-days estimates are available at global scale in the spatial resolution of about 1 km covering the period from 1999 to May 2014 in version 1.4 from SPOT/VEGETATION data and from June 2014 to June 2020 in version 1.5 from PROBA-V data."
       },
       "layout": {
+        "layerCard": {
+          "toggleable": true,
+          "controls": [
+            "zoomToCenter"
+          ],
+          "legend": {
+            "type": "image",
+            "visible": true,
+            "url": "https://land.copernicus.eu/en/products/vegetation/legends/legacy-legends/clms_global_fapar_1km_v1_10daily.png/@@images/image"
+          }
+        },
         "interfaceGroup": "Copernicus Land - Vegetation"
       },
       "data": {
@@ -825,6 +994,17 @@
         "description": "Quantifies the fraction of the solar radiation absorbed by live plants for photosynthesis. Every 10-days estimates are available at global scale in the spatial resolution of about 1 km covering the period from 1999 to June 2020 from SPOT/VEGETATION and PROBA-V data."
       },
       "layout": {
+        "layerCard": {
+          "toggleable": true,
+          "controls": [
+            "zoomToCenter"
+          ],
+          "legend": {
+            "type": "image",
+            "visible": true,
+            "url": "https://land.copernicus.eu/en/products/vegetation/legends/legacy-legends/clms_global_fapar_1km_v2_10daily.png/@@images/image"
+          }
+        },
         "interfaceGroup": "Copernicus Land - Vegetation"
       },
       "data": {
@@ -845,6 +1025,17 @@
         "description": "Defined as half of the total area of green elements of the canopy per unit horizontal ground area daily updates of Leaf Area Index are provided at pan-European level and in near real time. The data are available at 10 m x 10 m spatial resolution with the temporal extent from October 2016 to present."
       },
       "layout": {
+        "layerCard": {
+          "toggleable": true,
+          "controls": [
+            "zoomToCenter"
+          ],
+          "legend": {
+            "type": "image",
+            "visible": true,
+            "url": "https://land.copernicus.eu/en/products/vegetation/legends/hrvpp-legends/lailegend.png/@@images/image"
+          }
+        },
         "interfaceGroup": "Copernicus Land - Vegetation"
       },
       "data": {
@@ -865,6 +1056,17 @@
         "description": "Defined as half the total area of green elements of the canopy per unit horizontal ground area. Every 10-days estimates are available in near real time at global scale in the spatial resolution of about 300 m from January 2014 to June 2020 based upon PROBA-V data with version 1.0 and from July 2020 onwards based upon Sentinel-3/OLCI data with version 1.1."
       },
       "layout": {
+        "layerCard": {
+          "toggleable": true,
+          "controls": [
+            "zoomToCenter"
+          ],
+          "legend": {
+            "type": "image",
+            "visible": true,
+            "url": "https://land.copernicus.eu/en/products/vegetation/legends/legacy-legends/leafareaindexlegend-300m-1km-v1-v2.png/@@images/image"
+          }
+        },
         "interfaceGroup": "Copernicus Land - Vegetation"
       },
       "data": {
@@ -885,6 +1087,17 @@
         "description": "Defined as half the total area of green elements of the canopy per unit horizontal ground area. Every 10-days estimates are available at global scale in the spatial resolution of about 1 km covering the period from 1999 to May 2014 in version 1.4 from SPOT/VEGETATION data and from June 2014 to June 2020 in version 1.5 from PROBA-V data."
       },
       "layout": {
+        "layerCard": {
+          "toggleable": true,
+          "controls": [
+            "zoomToCenter"
+          ],
+          "legend": {
+            "type": "image",
+            "visible": true,
+            "url": "https://land.copernicus.eu/en/products/vegetation/legends/legacy-legends/lailegend.png/@@images/image"
+          }
+        },
         "interfaceGroup": "Copernicus Land - Vegetation"
       },
       "data": {
@@ -905,6 +1118,17 @@
         "description": "Defined as half the total area of green elements of the canopy per unit horizontal ground area. Every 10-days estimates are available at global scale in the spatial resolution of about 1 km covering the period from 1999 to June 2020 from SPOT/VEGETATION and PROBA-V data."
       },
       "layout": {
+        "layerCard": {
+          "toggleable": true,
+          "controls": [
+            "zoomToCenter"
+          ],
+          "legend": {
+            "type": "image",
+            "visible": true,
+            "url": "https://land.copernicus.eu/en/products/vegetation/legends/legacy-legends/leafareaindexlegend-300m-1km-v1-v2.png/@@images/image"
+          }
+        },
         "interfaceGroup": "Copernicus Land - Vegetation"
       },
       "data": {
@@ -925,6 +1149,17 @@
         "description": "Provides at pan-European level in the spatial resolution of 10 m and 100 m a forest classification for three thematic classes (all non-forest areas / broadleaved forest / coniferous forest) with the agricultural/urban trees removed for the 2018 reference year."
       },
       "layout": {
+        "layerCard": {
+          "toggleable": true,
+          "controls": [
+            "zoomToCenter"
+          ],
+          "legend": {
+            "type": "image",
+            "visible": true,
+            "url": "https://land.copernicus.eu/en/products/high-resolution-layer-forest-type/map-legends/hrl_forest_type_2018_10m.jpg/@@images/image"
+          }
+        },
         "interfaceGroup": "Copernicus Land - High Resolution Layer Forest Type"
       },
       "data": {
@@ -945,6 +1180,17 @@
         "description": "Provides at pan-European level in the spatial resolution of 20 m and 100 m a forest classification with three thematic classes (all non-forest areas / broadleaved forest / coniferous forest) for the 2015 reference year. In the 100 m spatial resolution the dataset has the agricultural/urban trees removed."
       },
       "layout": {
+        "layerCard": {
+          "toggleable": true,
+          "controls": [
+            "zoomToCenter"
+          ],
+          "legend": {
+            "type": "image",
+            "visible": true,
+            "url": "https://image.discomap.eea.europa.eu/arcgis/services/GioLandPublic/HRL_ForestType_2015/MapServer/WMSServer?request=GetLegendGraphic&version=1.0.0&format=image%2Fpng&layer=HRL_Forest_Type_2015_20m795"
+          }
+        },
         "interfaceGroup": "Copernicus Land - High Resolution Layer Forest Type"
       },
       "data": {
@@ -965,6 +1211,17 @@
         "description": "Provides at pan-European level in the spatial resolution of 20 m and 100 m a forest classification with three thematic classes (all non-forest areas / broadleaved forest / coniferous forest) for the 2012 reference year. In the 100 m spatial resolution the dataset has the agricultural/urban trees removed."
       },
       "layout": {
+        "layerCard": {
+          "toggleable": true,
+          "controls": [
+            "zoomToCenter"
+          ],
+          "legend": {
+            "type": "image",
+            "visible": true,
+            "url": "https://image.discomap.eea.europa.eu/arcgis/services/GioLandPublic/HRL_Forest_Cover_Type_2012/MapServer/WmsServer?request=GetLegendGraphic&version=1.0.0&format=image%2Fpng&layer=HRL_Forest_Type_2012_20m30052"
+          }
+        },
         "interfaceGroup": "Copernicus Land - High Resolution Layer Forest Type"
       },
       "data": {
@@ -985,6 +1242,17 @@
         "description": "Describes the difference between visible and near infrared reflectance of vegetation cover. Daily updates of Normalised Difference Vegetation Index are provided at pan-European level and in near real time. The data are available at 10 m x 10 m spatial resolution with the temporal extent from October 2016 to present."
       },
       "layout": {
+        "layerCard": {
+          "toggleable": true,
+          "controls": [
+            "zoomToCenter"
+          ],
+          "legend": {
+            "type": "image",
+            "visible": true,
+            "url": "https://land.copernicus.eu/en/products/vegetation/legends/hrvpp-legends/legend_ndvi.png/@@images/image"
+          }
+        },
         "interfaceGroup": "Copernicus Land - Vegetation"
       },
       "data": {
@@ -1005,6 +1273,17 @@
         "description": "NDVI is an indicator of the greenness of the biomes. Every 10-days estimates are available at global scale in the spatial resolution of about 300 m from 2014 to June 2020."
       },
       "layout": {
+        "layerCard": {
+          "toggleable": true,
+          "controls": [
+            "zoomToCenter"
+          ],
+          "legend": {
+            "type": "image",
+            "visible": true,
+            "url": "https://land.copernicus.eu/en/products/vegetation/legends/legacy-legends/ndvi.png/@@images/image"
+          }
+        },
         "interfaceGroup": "Copernicus Land - Vegetation"
       },
       "data": {
@@ -1025,6 +1304,17 @@
         "description": "NDVI is an indicator of the greenness of the biomes. Every 10-days estimates are available in near real time at global scale in the spatial resolution of about 300 m from July 2020 to the present."
       },
       "layout": {
+        "layerCard": {
+          "toggleable": true,
+          "controls": [
+            "zoomToCenter"
+          ],
+          "legend": {
+            "type": "image",
+            "visible": true,
+            "url": "https://land.copernicus.eu/en/products/vegetation/legends/legacy-legends/ndvi.png/@@images/image"
+          }
+        },
         "interfaceGroup": "Copernicus Land - Vegetation"
       },
       "data": {
@@ -1045,6 +1335,17 @@
         "description": "NDVI is an indicator of the greenness of the biomes. Every 10-days estimates are available at global scale in the spatial resolution of about 1 km from April 1998 to 2013 based upon SPOT/VEGETATION data and from 2014 to 2020 based upon PROBA-V data."
       },
       "layout": {
+        "layerCard": {
+          "toggleable": true,
+          "controls": [
+            "zoomToCenter"
+          ],
+          "legend": {
+            "type": "image",
+            "visible": true,
+            "url": "https://land.copernicus.eu/en/products/vegetation/legends/legacy-legends/ndvi.png/@@images/image"
+          }
+        },
         "interfaceGroup": "Copernicus Land - Vegetation"
       },
       "data": {
@@ -1065,6 +1366,17 @@
         "description": "NDVI is an indicator of the greenness of the biomes. Every 10-days estimates are available at global scale in the spatial resolution of about 1 km from 1999 to 2013 based upon SPOT/VEGETATION data and from 2014 to June 2020 based upon PROBA-V data."
       },
       "layout": {
+        "layerCard": {
+          "toggleable": true,
+          "controls": [
+            "zoomToCenter"
+          ],
+          "legend": {
+            "type": "image",
+            "visible": true,
+            "url": "https://land.copernicus.eu/en/products/vegetation/legends/legacy-legends/ndvi.png/@@images/image"
+          }
+        },
         "interfaceGroup": "Copernicus Land - Vegetation"
       },
       "data": {
@@ -1085,6 +1397,17 @@
         "description": "Based upon SPOT/VEGETATION and PROBA-V NDVI 1km version 2, long-term statistics include the minimum, median, maximum, mean, standard deviation and the number of observations over the 19-years period 1999-2017."
       },
       "layout": {
+        "layerCard": {
+          "toggleable": true,
+          "controls": [
+            "zoomToCenter"
+          ],
+          "legend": {
+            "type": "image",
+            "visible": true,
+            "url": "https://land.copernicus.eu/en/products/vegetation/legends/legacy-legends/ndvi.png/@@images/image"
+          }
+        },
         "interfaceGroup": "Copernicus Land - Vegetation"
       },
       "data": {
@@ -1105,6 +1428,17 @@
         "description": "Based upon SPOT/VEGETATION and PROBA-V NDVI 1km version 3, long-term statistics include the minimum, median, maximum, mean, standard deviation and the number of observations over the 21-years period 1999-2019.\n"
       },
       "layout": {
+        "layerCard": {
+          "toggleable": true,
+          "controls": [
+            "zoomToCenter"
+          ],
+          "legend": {
+            "type": "image",
+            "visible": true,
+            "url": "https://land.copernicus.eu/en/products/vegetation/legends/legacy-legends/ndvi.png/@@images/image"
+          }
+        },
         "interfaceGroup": "Copernicus Land - Vegetation"
       },
       "data": {


### PR DESCRIPTION
## Description

Release 1.0.1 of the Geospatial Explorer significantly changes the expected structure of the config files. There is now a new `meta` property for each source where 'shared' attributes for the source should now reside. 

The main difference between the versions is that attribution and description were previously nested within the layout/layercard objects whereas they now should be placed within the meta object.
The `legend` object has also shifted a number of it properties to reside in the `meta` object instead.